### PR TITLE
bugfix 部分设备安装的ffmpeg不支持libmp3lame编码

### DIFF
--- a/core/all_whisper_methods/whisperXapi.py
+++ b/core/all_whisper_methods/whisperXapi.py
@@ -10,9 +10,10 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(
 
 def convert_video_to_audio(input_file: str) -> str:
     os.makedirs('output/audio', exist_ok=True)
-    audio_file = 'output/audio/raw_full_audio.wav'
-    
-    if not os.path.exists(audio_file):
+    audio_file = 'output/audio/raw_full_audio'
+    audio_file_with_format = f'{audio_file}.wav'
+
+    if not os.path.exists(f'{audio_file}.wav'):
         ffmpeg_cmd = [
             'ffmpeg',
             '-i', input_file,
@@ -20,13 +21,40 @@ def convert_video_to_audio(input_file: str) -> str:
             '-acodec', 'libmp3lame',
             '-ar', '16000',
             '-b:a', '64k',
-            audio_file
+            f'{audio_file}.wav'
         ]
-        print(f"🎬➡️🎵 Converting to audio......")
-        subprocess.run(ffmpeg_cmd, check=True, stderr=subprocess.PIPE)
-        print(f"🎬➡️🎵 Converted <{input_file}> to <{audio_file}>\n")
-    
-    return audio_file
+        try:
+            print(f"🎬➡️🎵 Converting to audio with libmp3lame ......")
+            subprocess.run(ffmpeg_cmd, check=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+            print(f"🎬➡️🎵 Converted <{input_file}> to <{f'{audio_file}.wav'}> with libmp3lame\n")
+            audio_file_with_format = f'{audio_file}.wav'
+
+        except subprocess.CalledProcessError as e:
+            print("❌ libmp3lame failed. Retrying with aac ......")
+            print(f"Error output: {e.stderr.decode()}")
+
+            # 有时候会遇到ffmpeg不含libmp3lame解码器的错误，使用内置 flac无损编码 兜底进行音频转换的 fallback ffmpeg 命令
+            ffmpeg_cmd = [
+                'ffmpeg',
+                '-i', input_file,
+                '-vn',
+                '-acodec', 'flac',
+                '-ar', '16000',
+                '-b:a', '64k',
+                f'{audio_file}.flac'
+            ]
+
+            try:
+                subprocess.run(ffmpeg_cmd, check=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+                print(f"🎬➡️🎵 Converted <{input_file}> to <{f'{audio_file}.flac'}> with aac\n")
+                audio_file_with_format = f'{audio_file}.flac'
+
+            except subprocess.CalledProcessError as e:
+                print(f"❌ Failed to convert <{input_file}> to <{f'{audio_file}.flac'}> with both libmp3lame and aac.")
+                print(f"Error output: {e.stderr.decode()}")
+                raise
+
+    return audio_file_with_format
 
 def split_audio(audio_file: str, target_duration: int = 20*60, window: int = 60) -> List[Tuple[float, float]]:
     print("🔪 Splitting audio into segments...")

--- a/core/all_whisper_methods/whisper_timestamped.py
+++ b/core/all_whisper_methods/whisper_timestamped.py
@@ -1,4 +1,7 @@
 import os,sys
+
+from core.all_whisper_methods.whisperXapi import convert_video_to_audio
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 import subprocess
 import whisper_timestamped as whisper
@@ -12,24 +15,8 @@ import json
 def convert_video_to_audio_and_transcribe(input_file: str):
     from config import WHISPER_MODEL, MODEL_DIR, WHISPER_LANGUAGE
     # 🎬➡️🎵➡️📊 Convert video to audio and transcribe
-    os.makedirs('output/audio', exist_ok=True)
-    audio_file = 'output/audio/raw_full_audio.wav'
-    
-    if not os.path.exists(audio_file):
-        # Convert video to audio
-        ffmpeg_cmd = [
-            'ffmpeg',
-            '-i', input_file,
-            '-vn',
-            '-acodec', 'libmp3lame',
-            '-ar', '16000',
-            '-b:a', '64k',
-            audio_file
-        ]
-        print(f"🎬➡️🎵 Converting to audio......")
-        subprocess.run(ffmpeg_cmd, check=True, stderr=subprocess.PIPE)
-        print(f"🎬➡️🎵 Converted <{input_file}> to <{audio_file}>\n")
-    
+    audio_file = convert_video_to_audio(input_file)
+
     # Check file size
     if os.path.getsize(audio_file) > 25 * 1024 * 1024:
         print("⚠️ Warning: File size exceeds 25MB. Please use a smaller file.")


### PR DESCRIPTION
# bugfix 部分设备安装的ffmpeg不支持libmp3lame编码

现象：部分设备不支持libmp3lame编码，出现video->audio失败的问题。
修复：当遇到libmp3lame编码失败，采用flac无损格式兜底