### PR TITLE
bugfix:修复了二次处理同一个视频时，偶现会卡住的bug

### DIFF
--- a/core/all_whisper_methods/whisperXapi.py
+++ b/core/all_whisper_methods/whisperXapi.py
@@ -16,6 +16,7 @@ def convert_video_to_audio(input_file: str) -> str:
     if not os.path.exists(f'{audio_file}.wav'):
         ffmpeg_cmd = [
             'ffmpeg',
+            '-y', # 默认覆盖已有文件
             '-i', input_file,
             '-vn',
             '-acodec', 'libmp3lame',
@@ -30,12 +31,13 @@ def convert_video_to_audio(input_file: str) -> str:
             audio_file_with_format = f'{audio_file}.wav'
 
         except subprocess.CalledProcessError as e:
-            print("❌ libmp3lame failed. Retrying with aac ......")
             print(f"Error output: {e.stderr.decode()}")
+            print("❌ libmp3lame failed. Retrying with aac ......")
 
             # 有时候会遇到ffmpeg不含libmp3lame解码器的错误，使用内置 flac无损编码 兜底进行音频转换的 fallback ffmpeg 命令
             ffmpeg_cmd = [
                 'ffmpeg',
+                '-y', # 默认覆盖已有文件
                 '-i', input_file,
                 '-vn',
                 '-acodec', 'flac',
@@ -74,6 +76,7 @@ def split_audio(audio_file: str, target_duration: int = 20*60, window: int = 60)
         
         ffmpeg_cmd = [
             'ffmpeg',
+            '-y',
             '-i', audio_file,
             '-ss', str(window_start),
             '-to', str(window_end),
@@ -111,6 +114,7 @@ def transcribe_segment(audio_file: str, start: float, end: float) -> Dict:
     segment_file = f'output/audio/segment_{start:.2f}_{end:.2f}.wav'
     ffmpeg_cmd = [
         'ffmpeg',
+        '-y',
         '-i', audio_file,
         '-ss', str(start),
         '-to', str(end),
@@ -120,7 +124,7 @@ def transcribe_segment(audio_file: str, start: float, end: float) -> Dict:
     
     try:
         # Run ffmpeg command with timeout
-        subprocess.run(ffmpeg_cmd, check=True, stderr=subprocess.PIPE, timeout=30)
+        subprocess.run(ffmpeg_cmd, check=True, stderr=subprocess.PIPE, timeout=300)
     except subprocess.TimeoutExpired:
         print("⚠️ ffmpeg command timed out, retrying...")
         # If timeout occurs, try with a different encoding method

--- a/core/step7_merge_sub_to_vid.py
+++ b/core/step7_merge_sub_to_vid.py
@@ -41,6 +41,9 @@ def merge_subtitles_to_video():
         print("Subtitle files not found in the 'output' directory.")
         exit(1)
 
+    # 确定是否是macOS
+    macOS = os.name == 'posix' and os.uname().sysname == 'Darwin'
+
     ffmpeg_cmd = [
         'ffmpeg', '-i', video_file,
         '-vf', (
@@ -53,10 +56,14 @@ def merge_subtitles_to_video():
             f"PrimaryColour={TRANS_FONT_COLOR},OutlineColour={TRANS_OUTLINE_COLOR},OutlineWidth={TRANS_OUTLINE_WIDTH},"
             f"BackColour={TRANS_BACK_COLOR},Alignment=2,MarginV=25,BorderStyle=4'"
         ),
-        '-preset', 'veryfast', 
         '-y',
         output_video
     ]
+
+    # 根据是否是macOS添加不同的参数, macOS的ffmpeg不包含preset
+    if not macOS:
+        ffmpeg_cmd.insert(-2, '-preset')
+        ffmpeg_cmd.insert(-2, 'veryfast')
 
     print("🎬 Start merging subtitles to video...")
     start_time = time.time()

--- a/core/step9_uvr_audio.py
+++ b/core/step9_uvr_audio.py
@@ -30,7 +30,7 @@ def extract_audio(input_video, start_time, end_time, output_file):
     
     temp_audio = 'temp_audio.wav'
     with console.status("[bold green]Extracting audio..."):
-        subprocess.run(['ffmpeg', '-i', input_video, '-vn', '-acodec', 'pcm_s16le', '-ar', '44100', '-ac', '2', temp_audio], check=True)
+        subprocess.run(['ffmpeg', '-y', '-i', input_video, '-vn', '-acodec', 'pcm_s16le', '-ar', '44100', '-ac', '2', temp_audio], check=True)
     
     audio = AudioSegment.from_wav(temp_audio)
     extract = audio[start_ms:end_ms]
@@ -47,7 +47,7 @@ def uvr_audio_main(input_video):
     # step1 uvr5 降噪完整音频
     full_audio_path = os.path.join(output_dir, 'full_audio.wav')
     
-    subprocess.run(['ffmpeg', '-i', input_video, '-vn', '-acodec', 'pcm_s16le', '-ar', '44100', '-ac', '2', full_audio_path], check=True)
+    subprocess.run(['ffmpeg', '-y', '-i', input_video, '-vn', '-acodec', 'pcm_s16le', '-ar', '44100', '-ac', '2', full_audio_path], check=True)
     with console.status("[bold green]UVR5 processing full audio, Might take a while to save audio after 100% ..."):
         uvr5_for_videolingo(full_audio_path, output_dir)
     
@@ -91,6 +91,7 @@ def uvr_audio_main(input_video):
             
             ffmpeg_command = [
                 'ffmpeg',
+                '-y',
                 '-i', original_vocal_path,
                 '-ss', start_time,
                 '-to', end_time,

--- a/install.py
+++ b/install.py
@@ -145,37 +145,48 @@ def main():
     choice = console.input("Please enter the option number (1 or 2): ")
 
     # Install PyTorch and WhisperX
-    if choice == '1':
-        console.print(Panel("Installing PyTorch with CUDA support...", style="cyan"))
-        subprocess.check_call(["conda", "install", "pytorch==2.0.0", "torchaudio==2.0.0", "pytorch-cuda=11.8", "-c", "pytorch", "-c", "nvidia", "-y"])
-        
+    if platform.system() == 'Darwin':  # macOS do not support Nvidia CUDA
+        console.print(Panel("For MacOS, installing CPU version of PyTorch...", style="cyan"))
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "torch", "torchaudio"])
         print("Installing whisperX...")
         current_dir = os.getcwd()
         whisperx_dir = os.path.join(current_dir, "third_party", "whisperX")
         os.chdir(whisperx_dir)
         subprocess.check_call([sys.executable, "-m", "pip", "install", "-e", "."])
         os.chdir(current_dir)
-    elif choice == '2':
-        table = Table(title="PyTorch Version Selection")
-        table.add_column("Option", style="cyan", no_wrap=True)
-        table.add_column("Version", style="magenta")
-        table.add_column("Description", style="green")
-        table.add_row("1", "CPU", "Choose this if you're using Mac, non-NVIDIA GPU, or don't need GPU acceleration")
-        table.add_row("2", "GPU", "Significantly speeds up UVR5 voice separation. Strongly recommended if you need dubbing functionality and have an NVIDIA GPU.")
-        console.print(table)
-        
-        torch_choice = console.input("Please enter the option number (1 for CPU or 2 for GPU): ")
-        if torch_choice == '1':
-            console.print(Panel("Installing CPU version of PyTorch...", style="cyan"))
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "torch", "torchaudio"])
-        elif torch_choice == '2':
-            console.print(Panel("Installing GPU version of PyTorch with CUDA 11.8...", style="cyan"))
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "torch", "torchaudio", "--index-url", "https://download.pytorch.org/whl/cu118"])
+    else:  # Linux/Windows
+        if choice == '1':
+            console.print(Panel("Installing PyTorch with CUDA support...", style="cyan"))
+            subprocess.check_call(["conda", "install", "pytorch==2.0.0", "torchaudio==2.0.0", "pytorch-cuda=11.8", "-c", "pytorch", "-c", "nvidia", "-y"])
+
+            print("Installing whisperX...")
+            current_dir = os.getcwd()
+            whisperx_dir = os.path.join(current_dir, "third_party", "whisperX")
+            os.chdir(whisperx_dir)
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "-e", "."])
+            os.chdir(current_dir)
+        elif choice == '2':
+            table = Table(title="PyTorch Version Selection")
+            table.add_column("Option", style="cyan", no_wrap=True)
+            table.add_column("Version", style="magenta")
+            table.add_column("Description", style="green")
+            table.add_row("1", "CPU", "Choose this if you're using Mac, non-NVIDIA GPU, or don't need GPU acceleration")
+            table.add_row("2", "GPU", "Significantly speeds up UVR5 voice separation. Strongly recommended if you need dubbing functionality and have an NVIDIA GPU.")
+            console.print(table)
+
+            torch_choice = console.input("Please enter the option number (1 for CPU or 2 for GPU): ")
+            if torch_choice == '1':
+                console.print(Panel("Installing CPU version of PyTorch...", style="cyan"))
+                subprocess.check_call([sys.executable, "-m", "pip", "install", "torch", "torchaudio"])
+            elif torch_choice == '2':
+                console.print(Panel("Installing GPU version of PyTorch with CUDA 11.8...", style="cyan"))
+                subprocess.check_call([sys.executable, "-m", "pip", "install", "torch", "torchaudio", "--index-url", "https://download.pytorch.org/whl/cu118"])
+            else:
+                console.print("Invalid choice. Defaulting to CPU version.")
+                subprocess.check_call([sys.executable, "-m", "pip", "install", "torch", "torchaudio"])
         else:
-            console.print("Invalid choice. Defaulting to CPU version.")
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "torch", "torchaudio"])
-    else:
-        raise ValueError("Invalid choice. Please enter 1 or 2. Try again.")
+            raise ValueError("Invalid choice. Please enter 1 or 2. Try again.")
+
     # Install other dependencies
     install_requirements()
 


### PR DESCRIPTION
## 1.修复了二次处理同一个视频时，偶现会卡住的bug
- 原因是ffmpeg执行的时候没有默认覆盖已有文件，这里会卡住，添加默认'-y',默认覆盖 
## 2.修复了MAC系统不支持NVIDIA的CUDA的问题
## 3.修复了几个MAC系统ffmpeg操作失败的问题