### PR TITLE
fix tr_parts

### DIFF
--- a/core/step5_splitforsub.py
+++ b/core/step5_splitforsub.py
@@ -47,7 +47,7 @@ def align_subs(src_sub: str, tr_sub: str, src_part: str) -> Tuple[List[str], Lis
     align_data = parsed[f'align_{best}']
     
     src_parts = src_part.split('\n')
-    tr_parts = [item[f'target_part_{i+1}'].strip() for i, item in enumerate(align_data)]
+    tr_parts = [item[key].strip() for item in align_data for key in item if key.startswith('target_part_')]
     
     table = Table(title="🔗 Aligned parts")
     table.add_column("Language", style="cyan")


### PR DESCRIPTION

seems there are two possibilities for align_data, for example:

'In that example, we calculated\n the total probability of an event that can occur under different scenarios.'

This corresponds to 

```python
align_data = [
    {'src_part_1': 'In that example, we calculated', 'target_part_1': '在那个例子中，我们计算了'}, 
    {'src_part_2': ' the total probability of an event that can occur under different scenarios.', 'target_part_2': '事件在不同情景下发生的总概率。'}
]
```

The other situation is that all `target_part_x` in one dict, such as:

'except that now this would be an infinite sum over the infinite set of scenarios.'

This corresponds to 

```python
align_data = [
    {'src_part_1': 'except that now this would be', 'target_part_1': '只不过现在这会变成',
     '},        ': ': ',
     'src_part_2': 'an infinite sum over the infinite set of scenarios.', 'target_part_2': '在无限场景上的无限求和。'
     }
]

```

and The model I used is gpt-4o, video is [L02.7 Total Probability Theorem](https://www.youtube.com/watch?v=8odFouBR2wE), and the translation file is [translation_results.xlsx](https://github.com/user-attachments/files/17274484/translation_results.xlsx).
