### PR TITLE
Fix installation of ffmpeg in install.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -82,7 +82,7 @@ def main():
     def download_and_extract_ffmpeg():
         # requires both conda-ffmpeg and ffmpeg.exe
         console.print(Panel("📦 Installing ffmpeg through conda...", style="cyan"))
-        subprocess.check_call(["conda", "install", "-y", "ffmpeg"])
+        subprocess.check_call(["conda", "install", "-y", "ffmpeg"], shell=True)
 
         import requests
         system = platform.system()


### PR DESCRIPTION
Unable to install ffmpeg during setup with `OneKeyInstall&Start.bat`

Fix: Added `shell=True` parameter to `subprocess.check_call` when executing conda commands in `install.py` to ensure proper conda environment initialization.

here's traceback:

```
Traceback (most recent call last):
  File "C:\Users\iop\Downloads\VideoLingo\install.py", line 161, in <module>
    main()
  File "C:\Users\iop\Downloads\VideoLingo\install.py", line 154, in main
    download_and_extract_ffmpeg()
  File "C:\Users\iop\Downloads\VideoLingo\install.py", line 85, in download_and_extract_ffmpeg
    subprocess.check_call(["conda", "install", "-y", "ffmpeg"])
  File "C:\Users\iop\Downloads\VideoLingo\installer_files\env\lib\subprocess.py", line 364, in check_call
    retcode = call(*popenargs, **kwargs)
  File "C:\Users\iop\Downloads\VideoLingo\installer_files\env\lib\subprocess.py", line 345, in call
    with Popen(*popenargs, **kwargs) as p:
  File "C:\Users\iop\Downloads\VideoLingo\installer_files\env\lib\subprocess.py", line 966, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Users\iop\Downloads\VideoLingo\installer_files\env\lib\subprocess.py", line 1435, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
FileNotFoundError: [WinError 2] 系統找不到指定的檔案。
Command '"C:\Users\iop\Downloads\VideoLingo\installer_files\conda\condabin\conda.bat" activate "C:\Users\iop\Downloads\VideoLingo\installer_files\env" >nul && python install.py' failed with exit status code '1'. Exiting...
```