### PR TITLE
修复<br>处理失败

### DIFF
--- a/core/step3_2_splitbymeaning.py
+++ b/core/step3_2_splitbymeaning.py
@@ -19,6 +19,7 @@ def tokenize_sentence(sentence, nlp):
 
 def find_split_positions(original, modified):
     split_positions = []
+    modified = modified.replace('<br>', '[br]')
     parts = modified.split('[br]')
     start = 0
     whisper_language = load_key("whisper.language")


### PR DESCRIPTION
报错内容：

```
⚠️ Warning: No exact match found for sentence: Or for the guys trading the moneymaker,<br> they are still waiting for 50.
Difference positions:
Expected sentence: orfortheguystradingthemoneymakerbrtheyarestillwaitingfor50
Actual match: kersetupthanksforwatchingandillseeyouinthenextoneciaociao
Position markers: ^^^^^ ^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^
Difference indices: [0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 51, 52, 53, 54, 55, 56, 57]

Original sentence: Or for the guys trading the moneymaker,<br> they are still waiting for 50.
2024-12-01 17:20:20.266 Uncaught app exception
Traceback (most recent call last):
  File "D:\VideoLingo-2.0\installer_files\env\lib\site-packages\streamlit\runtime\scriptrunner\exec_code.py", line 88, in exec_func_with_error_handling
    result = func()
  File "D:\VideoLingo-2.0\installer_files\env\lib\site-packages\streamlit\runtime\scriptrunner\script_runner.py", line 590, in code_to_exec
    exec(code, module.__dict__)
  File "D:\VideoLingo-2.0\st.py", line 123, in <module>
    main()
  File "D:\VideoLingo-2.0\st.py", line 119, in main
    text_processing_section()
  File "D:\VideoLingo-2.0\st.py", line 33, in text_processing_section
    process_text()
  File "D:\VideoLingo-2.0\st.py", line 55, in process_text
    step4_2_translate_all.translate_all()
  File "D:\VideoLingo-2.0\core\step4_2_translate_all.py", line 119, in translate_all
    df_time = align_timestamp(df_text, df_translate, subtitle_output_configs, output_dir=None, for_display=False)
  File "D:\VideoLingo-2.0\core\step6_generate_final_timeline.py", line 120, in align_timestamp
    time_stamp_list = get_sentence_timestamps(df_text, df_translate)
  File "D:\VideoLingo-2.0\core\step6_generate_final_timeline.py", line 106, in get_sentence_timestamps
    raise ValueError("❎ No match found for sentence.")
ValueError: ❎ No match found for sentence.
```
不知道为啥出来个`<br>`
修改step3_2_splitbymeaning.py代码，补充替换 `modified = modified.replace('<br>', '[br]')`操作后修复