### PR TITLE
fix: prevent exception from calling `pynvml.nvmlShutdown()` before init pynvml

### DIFF
--- a/install.py
+++ b/install.py
@@ -19,8 +19,10 @@ def install_package(*packages):
 def check_nvidia_gpu():
     install_package("pynvml")
     import pynvml
+    pynvml_initialized = False
     try:
         pynvml.nvmlInit()
+        pynvml_initialized = True
         device_count = pynvml.nvmlDeviceGetCount()
         if device_count > 0:
             print(f"Detected NVIDIA GPU(s)")
@@ -36,7 +38,8 @@ def check_nvidia_gpu():
         print("No NVIDIA GPU detected or NVIDIA drivers not properly installed")
         return False
     finally:
-        pynvml.nvmlShutdown()
+        if pynvml_initialized:
+          pynvml.nvmlShutdown()
 
 def check_ffmpeg():
     from rich.console import Console


### PR DESCRIPTION
This pull request includes changes to the `check_nvidia_gpu` function in the `install.py` file to improve the handling of the `pynvml` library initialization and shutdown process.

Improvements to GPU check:

* [`install.py`](diffhunk://#diff-a5fa297e66b71ac1a8685caa5c37577774be2c36024ecda7abeb70bb50214d0fR22-R25): Added a flag `pynvml_initialized` to track the initialization state of `pynvml` and ensure it is only shut down if it was successfully initialized. [[1]](diffhunk://#diff-a5fa297e66b71ac1a8685caa5c37577774be2c36024ecda7abeb70bb50214d0fR22-R25) [[2]](diffhunk://#diff-a5fa297e66b71ac1a8685caa5c37577774be2c36024ecda7abeb70bb50214d0fR41)