### PR TITLE
Update step5_splitforsub.py, fix bugs: "arrays must have the same len…

### DIFF
--- a/core/step5_splitforsub.py
+++ b/core/step5_splitforsub.py
@@ -127,6 +127,13 @@ def split_for_sub_main():
         src = split_src
         trans = split_trans
 
+    # Make sure that the src and the remerged have the same length
+    # 确保二者有相同的长度，防止报错
+    if len(src) > len(remerged):
+        remerged += [None] * (len(src) - len(remerged))
+    elif len(remerged) > len(src):
+        src += [None] * (len(remerged) - len(src))
+    
     pd.DataFrame({'Source': split_src, 'Translation': split_trans}).to_excel(OUTPUT_SPLIT_FILE, index=False)
     pd.DataFrame({'Source': src, 'Translation': remerged}).to_excel(OUTPUT_REMERGED_FILE, index=False)
 


### PR DESCRIPTION
I have a bug when running the program:
```bash
File "/home/napbad/.conda/envs/videolingo/lib/python3.10/site-packages/streamlit/runtime/scriptrunner/exec_code.py", line 88, in exec_func_with_error_handling
    result = func()
File "/home/napbad/.conda/envs/videolingo/lib/python3.10/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 590, in code_to_exec
    exec(code, module.__dict__)
File "/home/napbad/Project/VideoLingo/st.py", line 123, in <module>
    main()
File "/home/napbad/Project/VideoLingo/st.py", line 119, in main
    text_processing_section()
File "/home/napbad/Project/VideoLingo/st.py", line 33, in text_processing_section
    process_text()
File "/home/napbad/Project/VideoLingo/st.py", line 57, in process_text
    step5_splitforsub.split_for_sub_main()
File "/home/napbad/Project/VideoLingo/core/step5_splitforsub.py", line 131, in split_for_sub_main
    pd.DataFrame({'Source': src, 'Translation': remerged}).to_excel(OUTPUT_REMERGED_FILE, index=False)
File "/home/napbad/.conda/envs/videolingo/lib/python3.10/site-packages/pandas/core/frame.py", line 778, in __init__
    mgr = dict_to_mgr(data, index, columns, dtype=dtype, copy=copy, typ=manager)
File "/home/napbad/.conda/envs/videolingo/lib/python3.10/site-packages/pandas/core/internals/construction.py", line 503, in dict_to_mgr
    return arrays_to_mgr(arrays, columns, index, dtype=dtype, typ=typ, consolidate=copy)
File "/home/napbad/.conda/envs/videolingo/lib/python3.10/site-packages/pandas/core/internals/construction.py", line 114, in arrays_to_mgr
    index = _extract_index(arrays)
File "/home/napbad/.conda/envs/videolingo/lib/python3.10/site-packages/pandas/core/internals/construction.py", line 677, in _extract_index
    raise ValueError("All arrays must be of the same length")
```

it is because that there are two arrays who should have the same length but not. So I fix it with some codes.:)

这是因为有两个数组应该具有相同的长度，但不是。所以我用一些代码修复它