### PR TITLE
Update whisperX_302.py

### DIFF
--- a/core/all_whisper_methods/whisperX_302.py
+++ b/core/all_whisper_methods/whisperX_302.py
@@ -26,7 +26,7 @@ def transcribe_audio_302(raw_audio_path: str, vocal_audio_path: str, start: floa
     y, sr = librosa.load(vocal_audio_path, sr=16000)
     audio_duration = len(y) / sr
     
-    if not start or not end:
+    if start is None or end is None:
         start = 0
         end = audio_duration
         


### PR DESCRIPTION
当 start=0 时not start 会返回 True（因为 0 在 Python 中视为 False） 导致 end 被错误地覆盖为 audio_duration