### PR TITLE
fix: omit response_format from API request when it is None

### DIFF
--- a/core/utils/ask_gpt.py
+++ b/core/utils/ask_gpt.py
@@ -64,9 +64,10 @@ def ask_gpt(prompt, resp_type=None, valid_def=None, log_title="default"):
     params = dict(
         model=model,
         messages=messages,
-        response_format=response_format,
         timeout=300
     )
+    if response_format is not None:
+        params["response_format"] = response_format
     resp_raw = client.chat.completions.create(**params)
 
     # process and return full result


### PR DESCRIPTION
## Summary
- When `api.llm_support_json` is `False`, `response_format` was set to `None` but still included in the API request body as `"response_format": null`
- Some OpenAI-compatible API providers try to parse this field and access `null.type`, causing a 400 error: `"Cannot read properties of null (reading 'type')"`

## Test plan
- [ ] Set `api.llm_support_json` to `false` and verify API requests no longer include `response_format: null`
- [ ] Set `api.llm_support_json` to `true` and verify `response_format: {"type": "json_object"}` is still sent correctly