### PR TITLE
fix: add missing numpy import in _11_merge_audio.py

### DIFF
--- a/core/_11_merge_audio.py
+++ b/core/_11_merge_audio.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 import pandas as pd
 import subprocess
 from pydub import AudioSegment


### PR DESCRIPTION
## Summary
- Add `import numpy as np` to `core/_11_merge_audio.py` to fix `NameError: name 'np' is not defined` during audio merging

## Problem
`_10_gen_audio.py` saves `new_sub_times` to Excel with `np.float64` values. When serialized to string, they become `np.float64(16.496)`. `_11_merge_audio.py` uses `eval()` to parse these strings but doesn't import numpy, causing:

```
Starting audio merging process...
NameError: name 'np' is not defined
```

## Root Cause
In `_11_merge_audio.py:22`, `eval()` is called on strings like `[[np.float64(16.496), np.float64(19.116)]]` but `np` (numpy) is not in scope.

## Fix
Add `import numpy as np` at the top of `core/_11_merge_audio.py`.

Fixes #543
Fixes #544

## Test plan
- [x] Reproduced the error locally
- [x] Applied fix and verified audio merging + video generation completes successfully