### PR TITLE
fix: sync detected_language when recognition language is changed in frontend

### DIFF
--- a/core/st_utils/sidebar_setting.py
+++ b/core/st_utils/sidebar_setting.py
@@ -175,6 +175,7 @@ def page_setting():
             )
             if langs[lang] != load_key("whisper.language"):
                 update_key("whisper.language", langs[lang])
+                update_key("whisper.detected_language", langs[lang])
                 st.rerun()
 
         runtime = st.selectbox(


### PR DESCRIPTION
Fixes #549

## Problem

When a user switches the recognition language in the frontend sidebar, only `whisper.language` was updated in the config, but `whisper.detected_language` was left unchanged. This caused NLP segmentation failures and other issues in subsequent steps because:

- `core/spacy_utils/load_nlp_model.py` reads `whisper.detected_language` to pick the right NLP model (when language is not English)
- `core/_3_2_split_meaning.py` reads `whisper.detected_language` when `whisper.language` is set to `auto`

## Solution

When the user manually selects a recognition language, also update `whisper.detected_language` to the same value, so both fields stay in sync.

## Testing

Manually verified that after changing the recognition language in the UI sidebar, `whisper.detected_language` in the config is correctly updated to match the selected language.