### PR TITLE
fix: treat extra files in batch input folder as warning, not error

### DIFF
--- a/batch/utils/settings_check.py
+++ b/batch/utils/settings_check.py
@@ -24,10 +24,9 @@ def check_settings():
     if files_not_in_excel:
         console.print(Panel(
             "\n".join([f"- {file}" for file in files_not_in_excel]),
-            title="[bold red]Warning: Files in input folder not mentioned in Excel sheet",
+            title="[bold yellow]Warning: Files in input folder not mentioned in Excel sheet",
             expand=False
         ))
-        all_passed = False
 
     for index, row in df.iterrows():
         video_file = row['Video File']


### PR DESCRIPTION
Fixes #518

## Problem

When the `batch/input` folder contains more files than are listed in `tasks_setting.xlsx`, `check_settings()` would set `all_passed = False` and fail the entire batch pre-flight check. This prevented processing the correctly configured tasks even though the extra input files are not actually an error condition.

The panel title also used `bold red` which is misleading for a non-fatal issue.

## Solution

- Remove the `all_passed = False` assignment from the extra-files branch so that having untracked files in the input folder is a warning only and does not block batch processing.
- Change the panel title color from `bold red` to `bold yellow` to better reflect the non-fatal severity.

## Testing

Placed an extra file in `batch/input` that is not referenced in `tasks_setting.xlsx`. The settings check now prints a yellow warning about the extra file but continues and returns `True` when all configured tasks are valid.