### PR TITLE
fix: strip leading dot from extension when checking audio format on upload

### DIFF
--- a/core/st_utils/download_video_section.py
+++ b/core/st_utils/download_video_section.py
@@ -58,7 +58,7 @@ def download_video_section():
                 with open(os.path.join(OUTPUT_DIR, clean_name), "wb") as f:
                     f.write(uploaded_file.getbuffer())
 
-                if ext.lower() in load_key("allowed_audio_formats"):
+                if ext.lower()[1:] in load_key("allowed_audio_formats"):
                     convert_audio_to_video(os.path.join(OUTPUT_DIR, clean_name))
                 st.rerun()
             else:


### PR DESCRIPTION
Fixes #553

## Problem

When a user uploads an MP3 or WAV file, the upload handler gets stuck in a
reload loop and the audio is never processed.

Root cause: `os.path.splitext()` returns the file extension **with** a leading
dot (e.g. `'.mp3'`), but `allowed_audio_formats` in `config.yaml` stores
values **without** the dot (e.g. `'mp3'`). The comparison

```python
if ext.lower() in load_key("allowed_audio_formats"):   # '.mp3' in ['mp3', 'wav', ...]
```

always evaluates to `False`, so `convert_audio_to_video()` is never called.
The audio file is saved to the output folder but `find_video_files()` ignores
it (it only matches video extensions), so the UI loops endlessly on the upload
widget.

This also explains why renaming the file to `.mp4` "works" — the video-format
branch is hit instead and `find_video_files()` picks it up.

## Solution

Strip the leading dot with `[1:]` before the membership test, consistent with
how `find_video_files()` already handles extensions:

```python
if ext.lower()[1:] in load_key("allowed_audio_formats"):
```

## Testing

- Uploaded an `.mp3` file: the UI now calls `convert_audio_to_video`, creates
  `black_screen.mp4`, removes the original audio file, and re-renders showing
  the video player as expected.
- Uploaded `.wav`, `.flac`, `.m4a` files: same behaviour.
- Uploaded a `.mp4` file: unaffected, works as before.