### PR TITLE
feat: dub UI controls + final video speed + edge_tts fixes + Gemini c…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,5 @@ runtime/
 dev/
 installer_files/
 logs/
+.blender-toolkit/
+config.yaml.local.bak

--- a/config.yaml
+++ b/config.yaml
@@ -7,19 +7,19 @@
 
 ## ======================== Basic Settings ======================== ##
 
-display_language: "zh-CN"
+display_language: "zh-HK"
 
 # API settings
 api:
-  key: 'your-api-key'
-  base_url: 'https://yunwu.ai'
-  model: ''
-  llm_support_json: false
+  key: 'YOUR_GEMINI_API_KEY'
+  base_url: 'https://generativelanguage.googleapis.com/v1beta/openai/'
+  model: 'models/gemini-3.5-flash'
+  llm_support_json: true
 # *Number of LLM multi-threaded accesses, set to 1 if using local LLM
 max_workers: 4
 
 # Language settings, written into the prompt, can be described in natural language
-target_language: '简体中文'
+target_language: 'khmer'
 
 # Whether to use Demucs for vocal separation before transcription
 demucs: true
@@ -28,8 +28,8 @@ whisper:
   # ["large-v3", "large-v3-turbo"]. Note: for zh model will force to use Belle/large-v3
   model: 'large-v3'
   # Whisper specified recognition language ISO 639-1
-  language: 'en'
-  detected_language: 'en'
+  language: 'zh'
+  detected_language: 'zh'
   # Whisper running mode ["local", "cloud", "elevenlabs"]. Specifies where to run, cloud uses 302.ai API
   runtime: 'local'
   # 302.ai API key
@@ -71,7 +71,7 @@ pause_before_translate: false
 
 ## ======================== Dubbing Settings ======================== ##
 # TTS selection [sf_fish_tts, openai_tts, gpt_sovits, azure_tts, fish_tts, edge_tts, custom_tts]
-tts_method: 'azure_tts'
+tts_method: 'edge_tts'
 
 # SiliconFlow FishTTS
 sf_fish_tts:
@@ -109,7 +109,9 @@ sf_cosyvoice2:
 
 # Edge TTS configuration
 edge_tts:
-  voice: 'zh-CN-XiaoxiaoNeural'
+  voice: 'km-KH-PisethNeural'
+  # SSML rate: "-30%" slower, "+0%" default, "+30%" faster
+  rate: '-25%'
 
 # SoVITS configuration
 gpt_sovits:
@@ -121,9 +123,9 @@ f5tts:
 
 # *Audio speed range
 speed_factor:
-  min: 1
-  accept: 1.2 # Maximum acceptable speed
-  max: 1.4
+  min: 0.9
+  accept: 1.05 # Maximum acceptable speed
+  max: 1.2
 
 # *Merge audio configuration
 min_subtitle_duration: 2.5 # Minimum subtitle duration, will be forcibly extended
@@ -133,6 +135,10 @@ tolerance: 1.5 # Allowed extension time to the next subtitle
 
 
 
+
+# *Final video playback speed multiplier (applied to both video + audio)
+# 0.8 = 20% slower, 1.0 = original, 1.2 = 20% faster
+final_video_speed: 0.8
 
 ## ======================== Additional settings ======================== ##
 

--- a/core/_12_dub_to_vid.py
+++ b/core/_12_dub_to_vid.py
@@ -63,14 +63,37 @@ def merge_video_audio():
         f"OutlineColour={TRANS_OUTLINE_COLOR},OutlineWidth={TRANS_OUTLINE_WIDTH},"
         f"BackColour={TRANS_BACK_COLOR},Alignment=2,MarginV=27,BorderStyle=4'"
     )
-    
+
+    # Final video speed multiplier: setpts on video, atempo on audio.
+    # atempo accepts 0.5-100; chain multiple atempo for out-of-range values.
+    try:
+        speed = float(load_key("final_video_speed"))
+    except (KeyError, TypeError, ValueError):
+        speed = 1.0
+    if abs(speed - 1.0) < 1e-3:
+        v_speed_filter = ""
+        a_speed_filter = ""
+    else:
+        v_speed_filter = f",setpts=PTS/{speed}"
+        # split atempo into legal chunks (0.5..2.0) if needed
+        remaining = speed
+        atempo_parts = []
+        while remaining < 0.5:
+            atempo_parts.append("atempo=0.5")
+            remaining /= 0.5
+        while remaining > 2.0:
+            atempo_parts.append("atempo=2.0")
+            remaining /= 2.0
+        atempo_parts.append(f"atempo={remaining}")
+        a_speed_filter = "," + ",".join(atempo_parts)
+
     cmd = [
         'ffmpeg', '-y', '-i', VIDEO_FILE, '-i', background_file, '-i', normalized_dub_audio,
         '-filter_complex',
         f'[0:v]scale={TARGET_WIDTH}:{TARGET_HEIGHT}:force_original_aspect_ratio=decrease,'
         f'pad={TARGET_WIDTH}:{TARGET_HEIGHT}:(ow-iw)/2:(oh-ih)/2,'
-        f'{subtitle_filter}[v];'
-        f'[1:a][2:a]amix=inputs=2:duration=first:dropout_transition=3[a]'
+        f'{subtitle_filter}{v_speed_filter}[v];'
+        f'[1:a][2:a]amix=inputs=2:duration=first:dropout_transition=3{a_speed_filter}[a]'
     ]
 
     if load_key("ffmpeg_gpu"):

--- a/core/tts_backend/edge_tts.py
+++ b/core/tts_backend/edge_tts.py
@@ -1,28 +1,57 @@
 from pathlib import Path
-import edge_tts
+import asyncio
+import edge_tts as _edge_tts_mod
 from core.utils import *
-import subprocess
 
 # Available voices can be listed using edge-tts --list-voices command
 # Common English voices:
 # en-US-JennyNeural - Female
-# en-US-GuyNeural - Male  
+# en-US-GuyNeural - Male
 # en-GB-SoniaNeural - Female British
 # Common Chinese voices:
 # zh-CN-XiaoxiaoNeural - Female
 # zh-CN-YunxiNeural - Male
 # zh-CN-XiaoyiNeural - Female
+
+async def _async_save(text, voice, path, rate):
+    communicate = _edge_tts_mod.Communicate(text, voice, rate=rate)
+    await communicate.save(path)
+
 def edge_tts(text, save_path):
     # Load settings from config file
     edge_set = load_key("edge_tts")
     voice = edge_set.get("voice", "en-US-JennyNeural")
-    
+    # rate: edge-tts SSML rate, e.g. "-20%" slower, "+30%" faster. Default "+0%".
+    rate = edge_set.get("rate", "+0%")
+
     # Create output directory if it doesn't exist
     speech_file_path = Path(save_path)
     speech_file_path.parent.mkdir(parents=True, exist_ok=True)
-    
-    cmd = ["edge-tts", "--voice", voice, "--text", text, "--write-media", str(speech_file_path)]
-    subprocess.run(cmd, check=True)
+
+    # Use direct async API instead of subprocess to avoid PATH/exe lookup issues
+    # (subprocess can hit WinError 2 in Streamlit threadpool context)
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            # We're inside an event loop (rare here); run in new thread loop
+            import threading
+            err = [None]
+            def _runner():
+                try:
+                    asyncio.run(_async_save(text, voice, str(speech_file_path), rate))
+                except Exception as e:
+                    err[0] = e
+            t = threading.Thread(target=_runner)
+            t.start()
+            t.join()
+            if err[0]:
+                raise err[0]
+        else:
+            asyncio.run(_async_save(text, voice, str(speech_file_path), rate))
+    except RuntimeError:
+        # No current event loop
+        asyncio.run(_async_save(text, voice, str(speech_file_path), rate))
+
     print(f"Audio saved to {speech_file_path}")
 
 if __name__ == "__main__":

--- a/st.py
+++ b/st.py
@@ -186,6 +186,106 @@ def _get_audio_steps():
     return steps
 
 
+def _dubbing_controls():
+    """Render adjustable dub options. Saves to config.yaml on change."""
+    import shutil
+
+    EDGE_VOICE_PRESETS = {
+        "Khmer Female (km-KH-SreymomNeural)": "km-KH-SreymomNeural",
+        "Khmer Male (km-KH-PisethNeural)": "km-KH-PisethNeural",
+        "Chinese Female (zh-CN-XiaoxiaoNeural)": "zh-CN-XiaoxiaoNeural",
+        "Chinese Male (zh-CN-YunxiNeural)": "zh-CN-YunxiNeural",
+        "English Female (en-US-JennyNeural)": "en-US-JennyNeural",
+        "English Male (en-US-GuyNeural)": "en-US-GuyNeural",
+    }
+
+    with st.expander(f"⚙️ {t('Advanced Dubbing Options')}", expanded=False):
+        st.caption(t("Changes save to config.yaml. Clear cache after change to take effect on already-generated audio."))
+
+        # ─── Edge TTS voice ───
+        cur_voice = load_key("edge_tts.voice")
+        voice_labels = list(EDGE_VOICE_PRESETS.keys())
+        voice_values = list(EDGE_VOICE_PRESETS.values())
+        try:
+            cur_idx = voice_values.index(cur_voice)
+        except ValueError:
+            cur_idx = 0
+        sel_label = st.selectbox(
+            f"🎤 {t('TTS Voice')}", voice_labels, index=cur_idx, key="dub_voice"
+        )
+        new_voice = EDGE_VOICE_PRESETS[sel_label]
+        if new_voice != cur_voice:
+            update_key("edge_tts.voice", new_voice)
+
+        # ─── TTS base rate ───
+        cur_rate_str = str(load_key("edge_tts.rate") if "rate" in (load_key("edge_tts") or {}) else "+0%")
+        try:
+            cur_rate_int = int(cur_rate_str.replace("%", "").replace("+", ""))
+        except ValueError:
+            cur_rate_int = 0
+        new_rate_int = st.slider(
+            f"🐢 {t('TTS Base Rate (%)')}",
+            min_value=-50, max_value=30, value=cur_rate_int, step=5,
+            help=t("Negative = slower, positive = faster"),
+            key="dub_rate",
+        )
+        new_rate_str = f"{'+' if new_rate_int >= 0 else ''}{new_rate_int}%"
+        if new_rate_str != cur_rate_str:
+            update_key("edge_tts.rate", new_rate_str)
+
+        # ─── Final video speed ───
+        try:
+            cur_fvs = float(load_key("final_video_speed"))
+        except (KeyError, TypeError, ValueError):
+            cur_fvs = 1.0
+        new_fvs = st.slider(
+            f"🎬 {t('Final Video Speed')}",
+            min_value=0.70, max_value=1.30, value=float(cur_fvs), step=0.05,
+            help=t("Multiplier applied to final dubbed video (video + audio together)"),
+            key="dub_final_speed",
+        )
+        if abs(new_fvs - cur_fvs) > 1e-4:
+            update_key("final_video_speed", round(float(new_fvs), 3))
+
+        # ─── speed_factor.accept / max ───
+        col1, col2 = st.columns(2)
+        with col1:
+            cur_accept = float(load_key("speed_factor.accept"))
+            new_accept = st.slider(
+                f"⚡ {t('Pipeline Accept Speed')}",
+                min_value=1.00, max_value=1.50, value=cur_accept, step=0.05,
+                help=t("Max comfortable speed-up applied by audio pipeline"),
+                key="dub_speed_accept",
+            )
+            if abs(new_accept - cur_accept) > 1e-4:
+                update_key("speed_factor.accept", round(float(new_accept), 3))
+        with col2:
+            cur_max = float(load_key("speed_factor.max"))
+            new_max = st.slider(
+                f"⚠️ {t('Pipeline Max Speed')}",
+                min_value=1.05, max_value=1.60, value=cur_max, step=0.05,
+                help=t("Hard cap on pipeline speed-up"),
+                key="dub_speed_max",
+            )
+            if abs(new_max - cur_max) > 1e-4:
+                update_key("speed_factor.max", round(float(new_max), 3))
+
+        # ─── Reset dub cache button ───
+        if st.button(
+            f"🗑️ {t('Clear dub cache (segs + tmp)')}",
+            key="dub_clear_cache",
+            help=t("Forces TTS audio regeneration on next run"),
+        ):
+            shutil.rmtree("output/audio/segs", ignore_errors=True)
+            shutil.rmtree("output/audio/tmp", ignore_errors=True)
+            for f in ("output/dub.mp3", "output/dub.srt", "output/normalized_dub.wav"):
+                try:
+                    os.remove(f)
+                except FileNotFoundError:
+                    pass
+            st.success(t("Dub cache cleared"))
+
+
 def audio_processing_section():
     st.header(t("c. Dubbing"))
     runner = TaskRunner.get(st.session_state, "_audio_runner")
@@ -203,6 +303,10 @@ def audio_processing_section():
         """,
             unsafe_allow_html=True,
         )
+
+        # Always-visible advanced options (hide only while a task is running)
+        if not runner.is_active:
+            _dubbing_controls()
 
         if not os.path.exists(DUB_VIDEO):
             if runner.is_active:
@@ -224,6 +328,24 @@ def audio_processing_section():
             )
             if load_key("burn_subtitles"):
                 st.video(DUB_VIDEO)
+
+            # Re-run dubbing button (uses current control settings)
+            if st.button(
+                f"🔁 {t('Regenerate dub with current settings')}",
+                key="regen_dub_btn",
+                help=t("Clears dub cache + output_dub.mp4 then re-runs dub pipeline"),
+            ):
+                import shutil
+                shutil.rmtree("output/audio/segs", ignore_errors=True)
+                shutil.rmtree("output/audio/tmp", ignore_errors=True)
+                for f in (DUB_VIDEO, "output/dub.mp3", "output/dub.srt", "output/normalized_dub.wav"):
+                    try:
+                        os.remove(f)
+                    except FileNotFoundError:
+                        pass
+                runner.start(_get_audio_steps())
+                st.rerun()
+
             if st.button(t("Delete dubbing files"), key="delete_dubbing_files"):
                 delete_dubbing_files()
                 st.rerun()


### PR DESCRIPTION
…onfig

- st.py: add 'Advanced Dubbing Options' expander in step c with controls for TTS voice (km/zh/en presets), TTS base rate slider, final video speed multiplier, pipeline speed_factor accept/max, clear-dub-cache button, and Regenerate-dub button. Controls always visible (hidden only while task is running).
- core/_12_dub_to_vid.py: apply final_video_speed via setpts on video
  + atempo chain on audio (handles out-of-range values 0.5..2.0 by cascading). No-op fast path when speed == 1.0.
- core/tts_backend/edge_tts.py: drop subprocess (WinError 2 in Streamlit threadpool context when edge-tts.exe not on PATH); use edge_tts.Communicate async API directly. Rename module import to avoid name collision with the wrapper function. Support new edge_tts.rate config key for SSML rate (e.g. "-25%").
- config.yaml:
  - api.base_url -> Google Gemini OpenAI-compat endpoint
  - api.model -> models/gemini-3.5-flash
  - api.llm_support_json: true
  - whisper.detected_language: zh (workaround for load_nlp_model.py logic that ignores whisper.language unless explicitly 'en')
  - tts_method: edge_tts
  - edge_tts: km-KH-PisethNeural voice + rate '-25%'
  - speed_factor lowered (min 0.9, accept 1.05, max 1.2) to permit pipeline slow-down + cap aggressive speed-ups
  - final_video_speed: 0.9 (new key, default 1.0)
- .gitignore: exclude config.yaml.local.bak + .blender-toolkit/