### PR TITLE
fix: preload OpenCV before core imports

### DIFF
--- a/st.py
+++ b/st.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import os, sys, time
+import cv2  # Preload OpenCV before the heavier core import chain on Windows.
 from core.st_utils.imports_and_utils import *
 from core.st_utils.task_runner import TaskRunner
 from core import *


### PR DESCRIPTION
### 概要
在 `st.py` 中提前导入 `cv2`，再导入较重的 `core` 模块链。

### 背景
Windows 下如果先导入 VideoLingo 的完整 `core` 链路，再导入 OpenCV，可能触发 `cv2` DLL 初始化失败，表现为 Streamlit 打印 URL 后静默退出。提前加载 OpenCV 可以规避这个 native DLL 导入顺序问题。

### 修改
- 在 `st.py` 中提前加入 `import cv2`。

### 验证
- 已验证 `python -c "import st; print('ok')"` 可正常执行。
- 已验证 Streamlit 启动后不会立即静默退出。