### PR TITLE
feat: use ASR segments for CJK NLP splitting

### DIFF
--- a/core/_2_asr.py
+++ b/core/_2_asr.py
@@ -1,6 +1,6 @@
 from core.utils import *
 from core.asr_backend.demucs_vl import demucs_audio
-from core.asr_backend.audio_preprocess import process_transcription, convert_video_to_audio, split_audio, save_results, normalize_audio_volume
+from core.asr_backend.audio_preprocess import process_transcription, convert_video_to_audio, split_audio, save_results, save_segments, normalize_audio_volume
 from core._1_ytdlp import find_video_files
 from core.utils.models import *
 
@@ -43,6 +43,7 @@ def transcribe():
         combined_result['segments'].extend(result['segments'])
     
     # 6. Process df
+    save_segments(combined_result)
     df = process_transcription(combined_result)
     save_results(df)
         

--- a/core/asr_backend/audio_preprocess.py
+++ b/core/asr_backend/audio_preprocess.py
@@ -177,5 +177,30 @@ def save_results(df: pd.DataFrame):
     df.to_excel(_2_CLEANED_CHUNKS, index=False)
     rprint(f"[green]📊 Excel file saved to {_2_CLEANED_CHUNKS}[/green]")
 
+def save_segments(result: Dict):
+    """Save ASR segment-level text for NLP splitting.
+
+    Word/character-level rows remain in cleaned_chunks.xlsx for precise timestamp
+    alignment. Segment text is a better input for spaCy/LLM splitting in CJK
+    languages where WhisperX alignment may be character-level.
+    """
+    os.makedirs('output/log', exist_ok=True)
+    rows = []
+    for segment in result.get('segments', []):
+        text = str(segment.get('text', '')).strip()
+        if not text and segment.get('words'):
+            text = ''.join(str(word.get('word', word.get('text', ''))) for word in segment['words']).strip()
+        if not text:
+            continue
+        rows.append({
+            'text': text,
+            'start': segment.get('start'),
+            'end': segment.get('end'),
+            'speaker_id': segment.get('speaker_id')
+        })
+
+    pd.DataFrame(rows, columns=['text', 'start', 'end', 'speaker_id']).to_excel(_2_ASR_SEGMENTS, index=False)
+    rprint(f"[green]📊 Segment file saved to {_2_ASR_SEGMENTS}[/green]")
+
 def save_language(language: str):
     update_key("whisper.detected_language", language)

--- a/core/asr_backend/whisperX_local.py
+++ b/core/asr_backend/whisperX_local.py
@@ -121,6 +121,7 @@ def transcribe_audio(raw_audio_file, vocal_audio_file, start, end):
 
     # Save language
     update_key("whisper.language", result['language'])
+    update_key("whisper.detected_language", result['language'])
     if result['language'] == 'zh' and WHISPER_LANGUAGE != 'zh':
         raise ValueError("Please specify the transcription language as zh and try again!")
 

--- a/core/spacy_utils/load_nlp_model.py
+++ b/core/spacy_utils/load_nlp_model.py
@@ -12,7 +12,8 @@ def get_spacy_model(language: str):
 
 @except_handler("Failed to load NLP Spacy model")
 def init_nlp():
-    language = "en" if load_key("whisper.language") == "en" else load_key("whisper.detected_language")
+    whisper_language = load_key("whisper.language")
+    language = load_key("whisper.detected_language") if whisper_language == "auto" else whisper_language
     model = get_spacy_model(language)
     rprint(f"[blue]⏳ Loading NLP Spacy model: <{model}> ...[/blue]")
     try:

--- a/core/spacy_utils/split_by_mark.py
+++ b/core/spacy_utils/split_by_mark.py
@@ -3,49 +3,97 @@ import pandas as pd
 import warnings
 from core.spacy_utils.load_nlp_model import init_nlp, SPLIT_BY_MARK_FILE
 from core.utils.config_utils import load_key, get_joiner
+from core.utils.models import _2_ASR_SEGMENTS, _2_CLEANED_CHUNKS
 from rich import print as rprint
 
 warnings.filterwarnings("ignore", category=FutureWarning)
+
+MAX_NLP_INPUT_BYTES = 40000
+
+def _clean_text(value):
+    if pd.isna(value):
+        return ''
+    return str(value or '').strip().strip('"').strip()
+
+def _split_text_by_bytes(text, max_bytes=MAX_NLP_INPUT_BYTES):
+    parts = []
+    current = ''
+    for char in text:
+        candidate = current + char
+        if current and len(candidate.encode('utf-8')) > max_bytes:
+            parts.append(current)
+            current = char
+        else:
+            current = candidate
+    if current:
+        parts.append(current)
+    return parts
+
+def _merge_units_by_bytes(units, joiner, max_bytes=MAX_NLP_INPUT_BYTES):
+    batches = []
+    current = ''
+    for unit in units:
+        if not unit:
+            continue
+        candidate = unit if not current else current + joiner + unit
+        if current and len(candidate.encode('utf-8')) > max_bytes:
+            batches.append(current)
+            current = unit
+        else:
+            current = candidate
+    if current:
+        batches.append(current)
+    return batches
+
+def _load_nlp_inputs(joiner):
+    if os.path.exists(_2_ASR_SEGMENTS):
+        segments = pd.read_excel(_2_ASR_SEGMENTS)
+        texts = [_clean_text(text) for text in segments.get('text', [])]
+        texts = [text for text in texts if text]
+        if texts:
+            rprint(f"[blue]🔍 Using ASR segment text for NLP splitting: {len(texts)} segment(s)[/blue]")
+            return [part for text in texts for part in _split_text_by_bytes(text)]
+
+    rprint(f"[yellow]⚠️ {_2_ASR_SEGMENTS} not found or empty, rebuilding NLP text from {_2_CLEANED_CHUNKS}.[/yellow]")
+    chunks = pd.read_excel(_2_CLEANED_CHUNKS)
+    texts = [_clean_text(text) for text in chunks.text.to_list()]
+    return _merge_units_by_bytes(texts, joiner)
 
 def split_by_mark(nlp):
     whisper_language = load_key("whisper.language")
     language = load_key("whisper.detected_language") if whisper_language == 'auto' else whisper_language # consider force english case
     joiner = get_joiner(language)
     rprint(f"[blue]🔍 Using {language} language joiner: '{joiner}'[/blue]")
-    chunks = pd.read_excel("output/log/cleaned_chunks.xlsx")
-    chunks.text = chunks.text.apply(lambda x: x.strip('"').strip(""))
-    
-    # join with joiner
-    input_text = joiner.join(chunks.text.to_list())
-
-    doc = nlp(input_text)
-    assert doc.has_annotation("SENT_START")
+    input_texts = _load_nlp_inputs(joiner)
 
     # skip - and ...
     sentences_by_mark = []
     current_sentence = []
     
     # iterate all sentences
-    for sent in doc.sents:
-        text = sent.text.strip()
-        
-        # check if the current sentence ends with - or ...
-        if current_sentence and (
-            text.startswith('-') or 
-            text.startswith('...') or
-            current_sentence[-1].endswith('-') or
-            current_sentence[-1].endswith('...')
-        ):
-            current_sentence.append(text)
-        else:
-            if current_sentence:
-                sentences_by_mark.append(' '.join(current_sentence))
-                current_sentence = []
-            current_sentence.append(text)
+    for input_text in input_texts:
+        doc = nlp(input_text)
+        assert doc.has_annotation("SENT_START")
+        for sent in doc.sents:
+            text = sent.text.strip()
+            
+            # check if the current sentence ends with - or ...
+            if current_sentence and (
+                text.startswith('-') or 
+                text.startswith('...') or
+                current_sentence[-1].endswith('-') or
+                current_sentence[-1].endswith('...')
+            ):
+                current_sentence.append(text)
+            else:
+                if current_sentence:
+                    sentences_by_mark.append(joiner.join(current_sentence))
+                    current_sentence = []
+                current_sentence.append(text)
     
     # add the last sentence
     if current_sentence:
-        sentences_by_mark.append(' '.join(current_sentence))
+        sentences_by_mark.append(joiner.join(current_sentence))
 
     with open(SPLIT_BY_MARK_FILE, "w", encoding="utf-8") as output_file:
         for i, sentence in enumerate(sentences_by_mark):

--- a/core/utils/models.py
+++ b/core/utils/models.py
@@ -3,6 +3,7 @@
 # ------------------------------------------
 
 _2_CLEANED_CHUNKS = "output/log/cleaned_chunks.xlsx"
+_2_ASR_SEGMENTS = "output/log/asr_segments.xlsx"
 _3_1_SPLIT_BY_NLP = "output/log/split_by_nlp.txt"
 _3_2_SPLIT_BY_MEANING = "output/log/split_by_meaning.txt"
 _4_1_TERMINOLOGY = "output/log/terminology.json"
@@ -31,6 +32,7 @@ _AUDIO_TMP_DIR = "output/audio/tmp"
 
 __all__ = [
     "_2_CLEANED_CHUNKS",
+    "_2_ASR_SEGMENTS",
     "_3_1_SPLIT_BY_NLP",
     "_3_2_SPLIT_BY_MEANING",
     "_4_1_TERMINOLOGY",


### PR DESCRIPTION
### 概要
新增 ASR segment 级文本作为 NLP 分句的优先输入，同时保留 word/char 级时间戳数据用于最终字幕时间轴对齐。并修复 spaCy 语言选择逻辑，为旧任务加入 fallback。

### 背景
对于日语/中文，WhisperX alignment 的 `words` 可能是字符级。旧流程会把这些字符级行直接拼成一整条超长字符串送进 spaCy，带来两个问题：
- 日语 Sudachi tokenizer 有单次输入字节限制，长文本会直接报错。
- NLP/LLM 分句拿到的是巨大字符流，而不是自然的 ASR segment 文本，分句质量差且容易触发 LLM 重试。

但最终时间戳对齐仍然需要字符级时间戳。因此本次修改把两个职责拆开：
- NLP/LLM 使用 segment 文本。
- 最终时间戳生成继续使用 word/character 级表。

### 修改
- 新增 `_2_ASR_SEGMENTS = "output/log/asr_segments.xlsx"`。
- 新增 `save_segments()` 保存 ASR segment 级文本。
- ASR 流程中调用 `save_segments()`。
- 本地 WhisperX 同步写入 `whisper.language` 和 `whisper.detected_language`。
- 修复 spaCy 语言选择逻辑：只要用户手动指定 `whisper.language`，就优先使用；只有 `auto` 才使用 `detected_language`。
- 修改 `split_by_mark.py`：
  - 优先读取 `asr_segments.xlsx`。
  - 如果没有该文件，则从旧的 `cleaned_chunks.xlsx` 重建文本。
  - 按 UTF-8 字节数切分长输入，避免超过 Sudachi tokenizer 限制。

### 验证
- 已通过 `py_compile` 检查。
- 已验证当前已有的字符级日语输出可以通过 fallback 生成 `split_by_nlp.txt`。
- 当前样本 fallback 结果为 484 行，最长行 342 字符。