### PR TITLE
Fix YouTube downloads merging to unsupported MKV

### DIFF
--- a/core/_1_ytdlp.py
+++ b/core/_1_ytdlp.py
@@ -30,6 +30,7 @@ def download_video_ytdlp(url, save_path='output', resolution='1080'):
         'outtmpl': f'{save_path}/%(title)s.%(ext)s',
         'noplaylist': True,
         'writethumbnail': True,
+        'merge_output_format': 'mp4',
         'postprocessors': [{'key': 'FFmpegThumbnailsConvertor', 'format': 'jpg'}],
     }
 


### PR DESCRIPTION
## Summary

Force yt-dlp merged YouTube downloads to use MP4.

## Problem

Depending on the selected video/audio formats, yt-dlp can merge a download into MKV. This can leave the UI unable to preview the downloaded video and may cause subtitle processing to fail with:

`Number of videos found 0 is not unique. Please check.`

## Fix

Set yt-dlp's `merge_output_format` to `mp4`, which is already supported throughout VideoLingo and by the Streamlit video player.

## Verification

- Reproduced with a YouTube download that merged H.264 video and Opus audio into MKV.
- Confirmed the resulting MP4 is detected by `find_video_files()` and displayed in the UI.