### PR TITLE
Fix Unicode console output on Windows

### DIFF
--- a/core/st_utils/task_runner.py
+++ b/core/st_utils/task_runner.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import threading
 import time
+import traceback
 from dataclasses import dataclass, field
 from typing import Callable
 
@@ -143,3 +144,4 @@ class TaskRunner:
         except Exception as e:
             self.error_msg = str(e)
             self.state = "error"
+            traceback.print_exc()

--- a/st.py
+++ b/st.py
@@ -1,5 +1,16 @@
-import streamlit as st
 import os, sys, time
+
+
+def _configure_utf8_console():
+    """Allow Rich and task threads to print Unicode on Windows."""
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
+
+
+_configure_utf8_console()
+
+import streamlit as st
 from core.st_utils.imports_and_utils import *
 from core.st_utils.task_runner import TaskRunner
 from core import *


### PR DESCRIPTION
## Summary

Configure the Streamlit entrypoint stdout/stderr streams to use UTF-8 and print background task tracebacks.

## Problem

On Windows installations created through the recommended `uv` setup, Python can inherit a legacy console encoding such as `cp1252`. VideoLingo prints Unicode symbols and emoji through Rich during subtitle processing, causing the background task to fail immediately with:

`UnicodeEncodeError: 'charmap' codec can't encode characters ...`

The UI only displays the exception message, which previously hid the traceback and made the failing call difficult to diagnose.

## Fix

- Reconfigure stdout and stderr to UTF-8 before importing Streamlit and application modules.
- Print background task tracebacks to stderr while preserving the existing UI error state.

## Verification

- Reproduced on Windows with Python 3.10 installed by `uv`, where stdout/stderr initially reported `cp1252`.
- Confirmed Rich can print `??????` after importing the updated entrypoint.
- Confirmed subtitle processing proceeds through audio conversion and starts WhisperX transcription instead of failing with `charmap`.