### PR TITLE
fix: refresh compatible dependencies and repair pandas 3 dubbing

### DIFF
--- a/OneKeyStart.bat
+++ b/OneKeyStart.bat
@@ -1,5 +1,7 @@
 @echo off
 setlocal EnableExtensions EnableDelayedExpansion
+chcp 65001 >nul
+set "PYTHONUTF8=1"
 cd /D "%~dp0"
 
 for /F "tokens=1,2 delims=#" %%A in ('"prompt #$H#$E# & echo on & for %%B in (1) do rem"') do set "ESC=%%B"
@@ -11,8 +13,8 @@ set "C_CYAN=%ESC%[36m"
 set "C_BOLD=%ESC%[1m"
 
 if not exist "logs" mkdir "logs"
-for /f "tokens=2 delims==" %%I in ('wmic os get localdatetime /value') do set dt=%%I
-set "LOGFILE=logs\videolingo_%dt:~0,8%_%dt:~8,6%.log"
+for /f %%I in ('powershell -NoProfile -Command "Get-Date -Format yyyyMMdd_HHmmss"') do set "dt=%%I"
+set "LOGFILE=logs\videolingo_%dt%.log"
 set "CHECK_ONLY="
 if /I "%~1"=="--check-only" set "CHECK_ONLY=1"
 
@@ -48,6 +50,7 @@ if %errorlevel%==0 (
         goto install_failed
     )
     python installer.py --check --quiet
+    if defined CHECK_ONLY exit /b !errorlevel!
     if errorlevel 1 (
         echo %C_YELLOW%Conda env is incomplete or outdated. Repairing...%C_RESET%
         python installer.py --yes
@@ -69,8 +72,10 @@ echo   python setup_env.py
 goto end
 
 :venv_found
+for %%I in ("%VENV_PY%") do set "PATH=%%~dpI;%PATH%"
 echo %C_GREEN%Detected %VENV_LABEL%:%C_RESET% %VENV_PY%
 "%VENV_PY%" installer.py --check --quiet
+if defined CHECK_ONLY exit /b %errorlevel%
 if errorlevel 1 (
     echo %C_YELLOW%Environment is incomplete or outdated. Repairing with installer.py...%C_RESET%
     "%VENV_PY%" installer.py --yes

--- a/core/_10_gen_audio.py
+++ b/core/_10_gen_audio.py
@@ -75,7 +75,8 @@ def process_row(row: pd.Series, tasks_df: pd.DataFrame) -> Tuple[int, float]:
 
 def generate_tts_audio(tasks_df: pd.DataFrame) -> pd.DataFrame:
     """Generate TTS audio sequentially and calculate actual duration"""
-    tasks_df['real_dur'] = 0
+    # pandas 3 rejects fractional durations assigned into an integer column.
+    tasks_df['real_dur'] = 0.0
     rprint("[bold green]🎯 Starting TTS audio generation...[/bold green]")
     
     with Progress() as progress:
@@ -177,7 +178,7 @@ def merge_chunks(tasks_df: pd.DataFrame) -> pd.DataFrame:
                     output_file = OUTPUT_FILE_TEMPLATE.format(f"{number}_{line_index}")
                     adjust_audio_speed(temp_file, output_file, speed_factor)
                     ad_dur = get_audio_duration(output_file)
-                    new_sub_times.append([cur_time, cur_time+ad_dur])
+                    new_sub_times.append([float(cur_time), float(cur_time+ad_dur)])
                     cur_time += ad_dur
                 # 🔄 Step3: Find corresponding main DataFrame index and update new_sub_times
                 main_df_idx = tasks_df[tasks_df['number'] == row['number']].index[0]
@@ -205,7 +206,9 @@ def merge_chunks(tasks_df: pd.DataFrame) -> pd.DataFrame:
                     
                     # Update the last timestamp
                     last_times = tasks_df.at[index, 'new_sub_times']
-                    last_times[-1][1] = chunk_end_time
+                    # NumPy 2 scalar repr includes np.float64(...), which is
+                    # not a portable literal when Excel serializes this list.
+                    last_times[-1][1] = float(chunk_end_time)
                     tasks_df.at[index, 'new_sub_times'] = last_times
                 else:
                     raise Exception(f"Chunk {chunk_start} to {index} exceeds the chunk end time {chunk_end_time:.2f} seconds with current time {cur_time:.2f} seconds")

--- a/core/_2_asr.py
+++ b/core/_2_asr.py
@@ -1,5 +1,4 @@
 from core.utils import *
-from core.asr_backend.demucs_vl import demucs_audio
 from core.asr_backend.audio_preprocess import process_transcription, convert_video_to_audio, prepare_audio_for_asr, split_audio, save_results, normalize_audio_volume
 from core._1_ytdlp import find_media_file
 from core.utils.models import *
@@ -15,6 +14,7 @@ def transcribe():
 
     # 2. Demucs vocal separation:
     if load_key("demucs"):
+        from core.asr_backend.demucs_vl import demucs_audio
         demucs_audio()
         vocal_audio = normalize_audio_volume(_VOCAL_AUDIO_FILE, _VOCAL_AUDIO_FILE, format="mp3")
     else:

--- a/core/_7_sub_into_vid.py
+++ b/core/_7_sub_into_vid.py
@@ -101,11 +101,12 @@ def merge_subtitles_to_video():
         if process.returncode == 0:
             rprint(f"\n✅ Done! Time taken: {time.time() - start_time:.2f} seconds")
         else:
-            rprint("\n❌ FFmpeg execution error")
+            raise subprocess.CalledProcessError(process.returncode, ffmpeg_cmd)
     except Exception as e:
         rprint(f"\n❌ Error occurred: {e}")
         if process.poll() is None:
             process.kill()
+        raise
 
 if __name__ == "__main__":
     merge_subtitles_to_video()

--- a/core/asr_backend/audio_preprocess.py
+++ b/core/asr_backend/audio_preprocess.py
@@ -1,5 +1,6 @@
 import os, subprocess
 import pandas as pd
+import math
 from typing import Dict, List, Tuple
 from pydub import AudioSegment
 from core.utils import *
@@ -8,6 +9,23 @@ from pydub import AudioSegment
 from pydub.silence import detect_silence
 from pydub.utils import mediainfo
 from rich import print as rprint
+
+
+def audio_slice_wav(path, start=None, end=None, sample_rate=16000):
+    """Decode only the requested interval to mono PCM WAV for cloud ASR."""
+    if any(value is not None and (not math.isfinite(value) or value < 0) for value in (start, end)):
+        raise ValueError('Audio interval must contain finite non-negative times')
+    cmd = ['ffmpeg', '-v', 'error']
+    if start is not None:
+        cmd += ['-ss', str(start)]
+    cmd += ['-i', str(path)]
+    if end is not None:
+        duration = end - (start or 0)
+        if duration <= 0:
+            raise ValueError('Audio interval must have positive duration')
+        cmd += ['-t', str(duration)]
+    cmd += ['-ac', '1', '-ar', str(sample_rate), '-c:a', 'pcm_s16le', '-f', 'wav', 'pipe:1']
+    return subprocess.run(cmd, check=True, capture_output=True).stdout
 
 def _ffmpeg_has_encoder(encoder_name: str) -> bool:
     """Check if the current ffmpeg installation supports a given audio encoder."""

--- a/core/asr_backend/elevenlabs_asr.py
+++ b/core/asr_backend/elevenlabs_asr.py
@@ -3,8 +3,7 @@ import json
 import time
 import requests
 import tempfile
-import librosa
-import soundfile as sf
+from core.asr_backend.audio_preprocess import audio_slice_wav
 from rich import print as rprint
 from core.utils import *
 
@@ -71,23 +70,11 @@ def transcribe_audio_elevenlabs(raw_audio_path, vocal_audio_path, start = None, 
         with open(LOG_FILE, "r", encoding="utf-8") as f:
             return json.load(f)
     
-    # Load audio and process start/end parameters
-    y, sr = librosa.load(vocal_audio_path, sr=16000)
-    audio_duration = len(y) / sr
-    
-    if start is None or end is None:
-        start = 0
-        end = audio_duration
-    
-    # Slice audio based on start/end
-    start_sample = int(start * sr)
-    end_sample = int(end * sr)
-    y_slice = y[start_sample:end_sample]
-    
-    # Create temporary file for the sliced audio
-    with tempfile.NamedTemporaryFile(suffix='.mp3', delete=False) as temp_file:
+    # Use the same FFmpeg decoder as the other cloud ASR backend.
+    audio_data = audio_slice_wav(vocal_audio_path, start, end)
+    with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as temp_file:
         temp_filepath = temp_file.name
-        sf.write(temp_filepath, y_slice, sr, format='MP3')
+        temp_file.write(audio_data)
     
     try:
         api_key = load_key("whisper.elevenlabs_api_key")
@@ -104,7 +91,7 @@ def transcribe_audio_elevenlabs(raw_audio_path, vocal_audio_path, start = None, 
         }
         
         with open(temp_filepath, 'rb') as audio_file:
-            files = {"file": (os.path.basename(temp_filepath), audio_file, 'audio/mpeg')}
+            files = {"file": (os.path.basename(temp_filepath), audio_file, 'audio/wav')}
             start_time = time.time()
             response = requests.post(base_url, headers=headers, data=data, files=files)
             

--- a/core/asr_backend/whisperX_302.py
+++ b/core/asr_backend/whisperX_302.py
@@ -3,8 +3,7 @@ import io
 import json
 import time
 import requests
-import librosa
-import soundfile as sf
+from core.asr_backend.audio_preprocess import audio_slice_wav
 from rich import print as rprint
 from core.utils import *
 from core.utils.models import *
@@ -21,20 +20,7 @@ def transcribe_audio_302(raw_audio_path: str, vocal_audio_path: str, start: floa
     update_key("whisper.language", WHISPER_LANGUAGE)
     url = "https://api.302.ai/302/whisperx"
     
-    y, sr = librosa.load(vocal_audio_path, sr=16000)
-    audio_duration = len(y) / sr
-    
-    if start is None or end is None:
-        start = 0
-        end = audio_duration
-        
-    start_sample = int(start * sr)
-    end_sample = int(end * sr)
-    y_slice = y[start_sample:end_sample]
-    
-    audio_buffer = io.BytesIO()
-    sf.write(audio_buffer, y_slice, sr, format='WAV', subtype='PCM_16')
-    audio_buffer.seek(0)
+    audio_buffer = io.BytesIO(audio_slice_wav(vocal_audio_path, start, end))
     
     files = [('audio_input', ('audio_slice.wav', audio_buffer, 'application/octet-stream'))]
     payload = {"processing_type": "align", "language": WHISPER_LANGUAGE, "output": "raw"}

--- a/core/tts_backend/edge_tts.py
+++ b/core/tts_backend/edge_tts.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import edge_tts
+import sys
 from core.utils import *
 import subprocess
 
@@ -21,7 +21,7 @@ def edge_tts(text, save_path):
     speech_file_path = Path(save_path)
     speech_file_path.parent.mkdir(parents=True, exist_ok=True)
     
-    cmd = ["edge-tts", "--voice", voice, "--text", text, "--write-media", str(speech_file_path)]
+    cmd = [sys.executable, "-m", "edge_tts", "--voice", voice, "--text", text, "--write-media", str(speech_file_path)]
     subprocess.run(cmd, check=True)
     print(f"Audio saved to {speech_file_path}")
 

--- a/docs/runtime-dependencies.md
+++ b/docs/runtime-dependencies.md
@@ -1,0 +1,79 @@
+# Runtime dependency refresh
+
+This change retains the existing WhisperX, Streamlit, subtitle and dubbing
+architecture. It updates application dependencies within compatible API ranges,
+without vendored libraries, package-metadata overrides or a CUDA 13 requirement.
+
+## Installation and updates
+
+`python setup_env.py --shared` creates/reuses the shared environment using Python
+3.13. Existing Python 3.10-3.13 environments can run `python installer.py` directly.
+Python 3.14 is outside the current WhisperX support range and is rejected before
+installation. Recreating an environment with a different Python version requires
+confirmation unless `--yes` is supplied.
+
+Use `python installer.py --upgrade` (inside the environment) or
+`python setup_env.py --shared --upgrade` to refresh dependencies within the declared
+ranges. Normal startup checks do not unconditionally upgrade dependencies.
+`OneKeyStart.bat --check-only` reports health without repairing or launching the app.
+
+### Why the GPU stack remains matched
+
+WhisperX 3.8.6 requires Torch/torchaudio 2.8, torchvision 0.23, TorchCodec 0.6-0.7
+and huggingface-hub below 1. Transformers 5 requires hub 1 or newer. Consequently,
+this refresh retains Transformers 4 and the matched Torch stack rather than
+forcing incompatible latest releases.
+
+The installer selects CUDA 12.8 wheels on drivers supporting CUDA 12.8 or newer,
+including CUDA 13-capable drivers, and CUDA 12.6 otherwise. CTranslate2's Windows
+build needs CUDA 12 cuBLAS. Drivers can be newer than the runtime used by the app.
+CPU wheels are explicitly selected on non-NVIDIA Windows/Linux systems.
+FFmpeg must be installed separately; TorchCodec requires a shared-library build
+for its decoding features. The project itself invokes the FFmpeg CLI.
+
+### Reduced installation complexity
+
+- Remove unused MoviePy and Replicate dependencies.
+- Remove the direct resampy requirement; remaining libraries manage their own
+  transitive dependencies.
+- Let pyannote-audio/WhisperX resolve Lightning instead of separately pinning
+  both Lightning distributions.
+- Use maintained PyPI Demucs 4.1 instead of a Git development snapshot and
+  `--no-deps` workaround. Training extras are not needed for inference.
+- Import Demucs only when separation is requested by the transcription stage.
+- Use one FFmpeg WAV slicing helper for the two cloud ASR backends instead of
+  decoding the entire audio through librosa and re-encoding separately.
+- Launch Edge TTS with the active Python interpreter, not a possibly unrelated
+  executable on the system PATH.
+
+## Validation
+
+Run `python -m pytest tests/test_dependencies.py` for targeted regression checks.
+The suite requires the app dependencies, pytest and FFmpeg.
+
+`tests/test_pipeline_integration.py` is explicitly opt-in and spends API credits.
+Set `VIDEOLINGO_TEST_AUDIO` to an English WAV and `VIDEOLINGO_TEST_API_KEY` to a
+valid OpenAI-compatible key. Optionally set `VIDEOLINGO_TEST_BASE_URL` and
+`VIDEOLINGO_TEST_MODEL`. It tests real translation, subtitle burn-in and Edge TTS
+dubbing through the existing background TaskRunner, plus audio-only subtitles.
+Generated outputs use pytest temporary directories and the temporary credential
+configuration is removed at teardown.
+
+Verified on Windows 11, NVIDIA RTX 4000 Ada (20 GB), Python 3.13.15 and FFmpeg 9.0.1
+shared build. The resolved environment has no dependency conflicts (`uv pip check`).
+Representative versions: WhisperX 3.8.6, Torch 2.8.0+cu128, CTranslate2 4.8.2,
+pyannote-audio 4.0.7, TorchCodec 0.7.0, spaCy 3.8.16, Streamlit 1.63.0,
+pandas 3.0.5, NumPy 2.5.3, OpenAI client 3.13.0 and Demucs 4.1.0.
+
+Real integration uses a roughly 15-second public English speech sample,
+OpenLux's OpenAI-compatible endpoint with gpt-5.5 for Simplified Chinese
+translation, and Edge TTS for Chinese dubbing. It checks generated subtitle,
+audio and video artifacts, not subjective translation or dubbing quality.
+The public sample is available at
+https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_en.wav.
+With `VIDEOLINGO_TEST_SERVER=1` and the integration variables supplied, the final
+suite passed all 15 checks, including a real HTTP/WebSocket first-page render.
+
+Not claimed as live-verified: Linux/macOS runtime, other ASR languages, YouTube
+availability, paid 302.ai/ElevenLabs/other TTS accounts, or GPT-SoVITS services.
+Cloud ASR slicing is tested locally without claiming successful cloud requests.

--- a/installer.py
+++ b/installer.py
@@ -34,8 +34,8 @@ REQUIREMENTS = ROOT / "requirements.txt"
 TORCH_VERSION = "2.8.0"
 TORCH_INDEX = "https://download.pytorch.org/whl"
 BOOTSTRAP_PACKAGES = ["requests", "rich", "ruamel.yaml", "InquirerPy", "packaging"]
-FILTERED_REQUIREMENTS = {"spacy", "whisperx"}
-DEMUX_GIT = "demucs[dev]@git+https://github.com/adefossez/demucs@b9ab48cad45976ba42b2ff17b229c071f0df9390"
+FILTERED_REQUIREMENTS = {"torch", "torchaudio", "torchvision"}
+DEMUCS_REQUIREMENT = "demucs>=4.1.0,<5"
 
 
 def run(cmd: list[str], retries: int = 0, env: dict[str, str] | None = None) -> None:
@@ -109,7 +109,7 @@ def requirements_hash() -> str:
     h = hashlib.sha256()
     h.update(REQUIREMENTS.read_bytes())
     h.update(f"torch={TORCH_VERSION}\n".encode())
-    h.update(DEMUX_GIT.encode())
+    h.update(DEMUCS_REQUIREMENT.encode())
     return h.hexdigest()
 
 
@@ -179,8 +179,7 @@ def detect_cuda_version_from_smi() -> tuple[int, int] | None:
 def detect_torch_index() -> str:
     cuda_version = detect_cuda_version_from_smi()
     tags = [
-        ((13, 0), "cu129"),
-        ((12, 9), "cu129"),
+        # CTranslate2 currently requires CUDA 12 cuBLAS, including on CUDA 13 drivers.
         ((12, 8), "cu128"),
         ((12, 6), "cu126"),
     ]
@@ -214,33 +213,36 @@ def maybe_configure_mirror(auto_mirror: bool) -> None:
 
 def install_torch(force: bool = False) -> None:
     print("\n[3/7] Install PyTorch / torchaudio")
-    if not force and package_ok("torch", TORCH_VERSION) and package_ok("torchaudio", TORCH_VERSION):
+    gpu = detect_nvidia_gpu()
+    gpu_build = not gpu or all("+cu12" in (package_version(name) or "") for name in ("torch", "torchaudio", "torchvision"))
+    if not force and gpu_build and package_ok("torch", TORCH_VERSION) and package_ok("torchaudio", TORCH_VERSION) and package_ok("torchvision", "0.23.0"):
         print(f"  torch {package_version('torch')} and torchaudio {package_version('torchaudio')} already installed.")
         return
-    packages = [f"torch=={TORCH_VERSION}", f"torchaudio=={TORCH_VERSION}"]
-    if detect_nvidia_gpu():
+    packages = [f"torch=={TORCH_VERSION}", f"torchaudio=={TORCH_VERSION}", "torchvision==0.23.0"]
+    if gpu:
         index = detect_torch_index()
         print(f"  NVIDIA GPU detected. Using PyTorch index: {index}")
-        pip_install(packages, retries=3, extra_args=["--index-url", index])
+        pip_install(packages, retries=3, extra_args=["--index-url", index, "--force-reinstall"])
     else:
         print("  No NVIDIA GPU detected. Installing CPU PyTorch wheels.")
-        pip_install(packages, retries=3)
+        extra = ["--index-url", f"{TORCH_INDEX}/cpu"] if platform.system() != "Darwin" else []
+        pip_install(packages, retries=3, extra_args=extra)
 
 
-def install_base_requirements(force: bool = False) -> None:
+def install_base_requirements(force: bool = False, upgrade: bool = False) -> None:
     print("\n[4/7] Install base requirements")
     state = load_state()
     current_hash = requirements_hash()
     previous_hash = state.get("requirements_hash")
-    if not force and previous_hash == current_hash and health_check(quiet=True, require_demucs=False, check_state=False) == 0:
+    if not force and not upgrade and previous_hash == current_hash and health_check(quiet=True, require_demucs=False, check_state=False) == 0:
         print("  Environment already matches requirements hash; skipping base install.")
         return
-    if not force and previous_hash is None and health_check(quiet=True, require_demucs=False, check_state=False) == 0:
+    if not force and not upgrade and previous_hash is None and health_check(quiet=True, require_demucs=False, check_state=False) == 0:
         print("  Packages are already healthy; writing fresh install state later.")
         return
     if previous_hash and previous_hash != current_hash:
         print("  requirements.txt changed; syncing base requirements.")
-    pip_install(read_base_requirements(), retries=3)
+    pip_install(read_base_requirements(), retries=3, extra_args=["--upgrade"])
 
 
 def install_spacy(force: bool = False) -> None:
@@ -258,19 +260,18 @@ def install_whisperx(force: bool = False) -> None:
     if not force and package_version("whisperx") is not None:
         print(f"  whisperx {package_version('whisperx')} already installed.")
         return
-    pip_install(["whisperx>=3.8.1"], retries=3)
+    pip_install(["whisperx>=3.8.6,<3.9"], retries=3)
 
 
 def install_demucs(force: bool = False, require: bool = False) -> None:
     print("\n[7/7] Install Demucs (optional)")
-    if not force and package_version("demucs") is not None and import_ok("demucs.api"):
+    from packaging.version import Version
+    if not force and package_version("demucs") is not None and Version("4.1.0") <= Version(package_version("demucs")) < Version("5") and import_ok("demucs.api"):
         print(f"  demucs {package_version('demucs')} already installed.")
         return
-    pip_install(["dora-search", "openunmix", "lameenc"], retries=3)
-    if soft_pip_install([DEMUX_GIT], retries=2, extra_args=["--no-deps"]):
-        return
-    print("  Falling back to PyPI demucs. Demucs is optional; install can continue if this fails.")
-    ok = soft_pip_install(["demucs==4.0.1"], retries=2, extra_args=["--no-deps"])
+    # Maintained Demucs separates inference and training dependencies. No git
+    # snapshot, no-deps installation, or torchaudio<2.2 workaround is needed.
+    ok = soft_pip_install([DEMUCS_REQUIREMENT], retries=2, extra_args=["--upgrade"])
     if require and not ok:
         raise RuntimeError("Demucs installation failed")
 
@@ -350,6 +351,21 @@ def install_linux_noto_fonts() -> None:
 def health_check(quiet: bool = False, require_demucs: bool = False, check_state: bool = True) -> int:
     errors: list[str] = []
     warnings: list[str] = []
+    if not (3, 10) <= sys.version_info[:2] < (3, 14):
+        errors.append("WhisperX requires Python >=3.10,<3.14; use setup_env.py")
+    try:
+        from packaging.requirements import Requirement
+        for raw in REQUIREMENTS.read_text(encoding="utf-8").splitlines():
+            if not requirement_name(raw):
+                continue
+            req = Requirement(raw)
+            if req.marker and not req.marker.evaluate():
+                continue
+            installed = package_version(req.name)
+            if installed is None or not req.specifier.contains(installed):
+                errors.append(f"unsatisfied requirement: {req} (installed: {installed})")
+    except ImportError:
+        errors.append("missing package: packaging")
     state = load_state()
     if check_state:
         if state.get("requirements_hash") and state.get("requirements_hash") != requirements_hash():
@@ -379,6 +395,8 @@ def health_check(quiet: bool = False, require_demucs: bool = False, check_state:
         warnings.append("Noto CJK fonts are not installed; CJK subtitle burn-in may fail")
     if not shutil.which("ffmpeg"):
         errors.append("ffmpeg not found in PATH")
+    if detect_nvidia_gpu() and not all("+cu12" in (package_version(name) or "") for name in ("torch", "torchaudio", "torchvision")):
+        errors.append("NVIDIA GPU detected but the matched CUDA 12 PyTorch wheels are missing; rerun installer.py")
     if not quiet:
         print("\nEnvironment check")
         for package in ["streamlit", "torch", "torchaudio", "spacy", "whisperx", "demucs"]:
@@ -397,14 +415,17 @@ def launch_streamlit() -> int:
 
 
 def install_all(args: argparse.Namespace) -> int:
+    if not (3, 10) <= sys.version_info[:2] < (3, 14):
+        print("ERROR: WhisperX requires Python >=3.10,<3.14. Run setup_env.py first.")
+        return 1
     install_bootstrap()
     maybe_configure_mirror(args.auto_mirror)
     install_torch(force=args.force)
-    install_base_requirements(force=args.force)
+    install_base_requirements(force=args.force, upgrade=args.upgrade)
     install_spacy(force=args.force)
     install_whisperx(force=args.force)
     if not args.skip_demucs:
-        install_demucs(force=args.force, require=args.require_demucs)
+        install_demucs(force=args.force or args.upgrade, require=args.require_demucs)
     install_project_metadata()
     install_linux_noto_fonts()
     ffmpeg_ok = check_ffmpeg()
@@ -423,6 +444,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--check", action="store_true", help="check environment health only")
     parser.add_argument("--quiet", action="store_true", help="quiet check output")
     parser.add_argument("--force", action="store_true", help="force reinstall staged packages")
+    parser.add_argument("--upgrade", action="store_true", help="refresh dependencies within requirements.txt compatibility bounds")
     parser.add_argument("--auto-mirror", action="store_true", help="auto-select and configure a PyPI mirror")
     parser.add_argument("--skip-demucs", action="store_true", help="skip optional Demucs install")
     parser.add_argument("--require-demucs", action="store_true", help="fail if Demucs cannot be installed")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,39 +1,40 @@
-librosa==0.11.0
-pytorch-lightning==2.6.1
-lightning==2.6.1
-transformers>=4.48.0
-moviepy==1.0.3
-numpy>=2.0.2
-openai>=1.55.3,<2
-opencv-python==4.11.0.86
-openpyxl==3.1.5
-pandas>=2.2.3
-pydub==0.25.1
-PyYAML==6.0.3
-replicate==0.33.0
-requests==2.32.5
-resampy==0.4.3
-# Keep spaCy on the 3.8 line. Exact patch pins can be unavailable for a
-# specific Python minor version on some mirrors, which makes setup brittle.
+# Application dependencies. Upper bounds limit untested major/API changes;
+# install with installer.py so PyTorch uses the correct CPU/CUDA wheel index.
+librosa>=0.11,<2
+transformers>=4.57.6,<5
+numpy>=2.1,<3
+openai>=1.109.1,<4
+opencv-python>=4.11,<6
+openpyxl>=3.1.5,<4
+pandas>=2.2.3,<4
+pydub>=0.25.1,<0.26
+PyYAML>=6.0.3,<7
+requests>=2.32.5,<3
 spacy>=3.8.7,<3.9
-streamlit==1.49.1
-streamlit-searchbox
-yt-dlp
-json-repair
-ruamel.yaml
-InquirerPy
-autocorrect-py
-ctranslate2>=4.5.0
-edge-tts
-pyannote-audio>=4.0.0
+streamlit>=1.49.1,<2
+streamlit-searchbox>=0.1.24,<0.2
+yt-dlp>=2026.6.9
+json-repair>=0.58.6,<1
+ruamel.yaml>=0.19.1,<0.20
+InquirerPy>=0.3.4,<0.4
+autocorrect-py>=2.14,<3
+ctranslate2>=4.5,<5
+edge-tts>=7.2.8,<8
+pyannote-audio>=4.0.4,<5
 
-# demucs and whisperx are installed separately in install.py
-# to avoid torchaudio version conflicts between demucs (<2.2) and whisperx (~=2.8.0).
-# Both work fine with torchaudio 2.8+ at runtime (tested up to 2.8.0+cu128).
-whisperx>=3.8.1
+# WhisperX 3.8 uses the matched Torch 2.8 / torchvision 0.23 / TorchCodec 0.7
+# family. Transformers 5 requires huggingface-hub >=1, which conflicts with
+# WhisperX's hub<1 requirement. Keep these constraints until upstream supports it.
+whisperx>=3.8.6,<3.9
+torch==2.8.0
+torchaudio==2.8.0
+torchvision==0.23.0
+torchcodec>=0.7,<0.8
+huggingface-hub>=0.36.2,<1
+audioop-lts>=0.2.2; python_version >= '3.13'
 
-syllables
-pypinyin
-g2p-en
-xmltodict
+syllables>=1.1.5,<2
+pypinyin>=0.55,<1
+g2p-en>=2.1,<3
+xmltodict>=1.0.4,<2
 

--- a/setup_env.py
+++ b/setup_env.py
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 
 
-PYTHON_VERSION = "3.10"
+PYTHON_VERSION = "3.13"
 SCRIPT_DIR = Path(__file__).resolve().parent
 LOCAL_VENV = SCRIPT_DIR / ".venv"
 SHARED_VENV = Path.home() / ".venvs" / "videolingo"
@@ -94,7 +94,7 @@ def python_version_ok(python_exe: Path) -> bool:
     if not python_exe.is_file():
         return False
     result = subprocess.run([str(python_exe), "--version"], capture_output=True, text=True)
-    return "3.10" in (result.stdout or result.stderr)
+    return f"Python {PYTHON_VERSION}." in (result.stdout or result.stderr)
 
 
 def create_venv(path: Path, yes: bool = False) -> Path:
@@ -107,7 +107,7 @@ def create_venv(path: Path, yes: bool = False) -> Path:
 
     if path.exists():
         if not yes:
-            answer = input(f"  Existing venv at {path} is not Python 3.10. Remove and recreate it? [y/N] ").strip().lower()
+            answer = input(f"  Existing venv at {path} is not Python {PYTHON_VERSION}. Remove and recreate it? [y/N] ").strip().lower()
             if answer != "y":
                 raise SystemExit("Cancelled.")
         shutil.rmtree(path, ignore_errors=True)
@@ -115,7 +115,7 @@ def create_venv(path: Path, yes: bool = False) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     run(["uv", "venv", "--seed", "--python", PYTHON_VERSION, str(path)], cwd=SCRIPT_DIR)
     if not python_version_ok(python_exe):
-        raise SystemExit("ERROR: failed to create a Python 3.10 virtual environment")
+        raise SystemExit(f"ERROR: failed to create a Python {PYTHON_VERSION} virtual environment")
     return python_exe
 
 
@@ -128,6 +128,8 @@ def run_installer(python_exe: Path, args: argparse.Namespace) -> None:
         cmd.append("--auto-mirror")
     if args.force:
         cmd.append("--force")
+    if args.upgrade:
+        cmd.append("--upgrade")
     if args.skip_demucs:
         cmd.append("--skip-demucs")
     if args.require_demucs:
@@ -144,6 +146,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--skip-demucs", action="store_true", help="skip optional Demucs install")
     parser.add_argument("--require-demucs", action="store_true", help="fail if Demucs cannot be installed")
     parser.add_argument("--force", action="store_true", help="force reinstall staged packages")
+    parser.add_argument("--upgrade", action="store_true", help="refresh dependencies within compatibility bounds")
     parser.add_argument("--yes", action="store_true", help="non-interactive; recreate wrong-version venvs")
     return parser
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,152 @@
+"""Regression checks for staged installation and shared audio decoding."""
+import importlib.util
+import io
+from pathlib import Path
+import subprocess
+import wave
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location('installer', ROOT / 'installer.py')
+installer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(installer)
+
+
+@pytest.mark.parametrize('cuda,tag', [((13, 4),'cu128'), ((12, 8),'cu128'), ((12, 6),'cu126'), (None,'cu126')])
+def test_cuda_index(monkeypatch, cuda, tag):
+    monkeypatch.setattr(installer, 'detect_cuda_version_from_smi', lambda: cuda)
+    assert installer.detect_torch_index().endswith('/' + tag)
+
+
+def test_requirements_exclude_staged_torch():
+    names = {installer.requirement_name(r) for r in installer.read_base_requirements()}
+    assert not names.intersection({'torch', 'torchaudio', 'torchvision'})
+    assert {'whisperx', 'spacy', 'torchcodec'} <= names
+    assert not names.intersection({'moviepy', 'replicate', 'resampy'})
+
+
+def test_cpu_torch_repaired_on_gpu(monkeypatch):
+    versions = {'torch':'2.8.0+cpu', 'torchaudio':'2.8.0+cpu', 'torchvision':'0.23.0+cpu'}
+    monkeypatch.setattr(installer, 'package_version', versions.get)
+    monkeypatch.setattr(installer, 'detect_nvidia_gpu', lambda: True)
+    monkeypatch.setattr(installer, 'detect_torch_index', lambda: installer.TORCH_INDEX + '/cu128')
+    calls = []
+    monkeypatch.setattr(installer, 'pip_install', lambda packages, **kwargs: calls.append((packages, kwargs)))
+    installer.install_torch()
+    assert calls and 'torchvision==0.23.0' in calls[0][0]
+    assert '--force-reinstall' in calls[0][1]['extra_args']
+
+
+def test_audio_slice(tmp_path):
+    from core.asr_backend.audio_preprocess import audio_slice_wav
+    path = tmp_path / 'audio.wav'
+    subprocess.run(['ffmpeg', '-v','error','-f','lavfi','-i','sine=frequency=440:duration=3','-ar','44100',str(path)], check=True)
+    data = audio_slice_wav(path, 1, 2)
+    with wave.open(io.BytesIO(data)) as wav:
+        assert wav.getframerate() == 16000
+        assert wav.getnchannels() == 1
+        samples = wav.readframes(32000)
+        assert len(samples) == 32000
+    with pytest.raises(ValueError):
+        audio_slice_wav(path, 2, 1)
+
+
+def test_homepage():
+    from streamlit.testing.v1 import AppTest
+    app = AppTest.from_file(ROOT / 'st.py', default_timeout=60).run()
+    assert not app.exception
+
+
+def test_fractional_tts_durations(monkeypatch):
+    import pandas as pd
+    from core import _10_gen_audio as audio
+    monkeypatch.setattr(audio, 'process_row', lambda row, tasks: (row['number'], 4.08))
+    monkeypatch.setattr(audio, 'load_key', lambda key: 'edge_tts' if key == 'tts_method' else 2)
+    tasks = pd.DataFrame({'number': range(7)})
+    result = audio.generate_tts_audio(tasks)
+    assert result['real_dur'].tolist() == [4.08] * 7
+
+
+def test_edge_tts_uses_current_interpreter(monkeypatch, tmp_path):
+    import sys
+    from core.tts_backend import edge_tts as backend
+    monkeypatch.setattr(backend, 'load_key', lambda key: {'voice':'en-US-JennyNeural'})
+    calls = []
+    monkeypatch.setattr(backend.subprocess, 'run', lambda cmd, **kwargs: calls.append(cmd))
+    backend.edge_tts('hello', tmp_path / 'speech.mp3')
+    assert calls[0][:3] == [sys.executable, '-m', 'edge_tts']
+
+
+def test_numpy_timestamps_roundtrip(monkeypatch, tmp_path):
+    import ast
+    import numpy as np
+    import pandas as pd
+    from core import _10_gen_audio as audio
+    monkeypatch.setattr(audio, 'load_key', lambda key: 1.2 if key.endswith('accept') else 1.0)
+    monkeypatch.setattr(audio, 'adjust_audio_speed', lambda *args: None)
+    monkeypatch.setattr(audio, 'get_audio_duration', lambda path: 0.5)
+    tasks = pd.DataFrame({'number':[1,2], 'cut_off':[0,1], 'real_dur':[0.5,0.5], 'tol_dur':[1.0,1.0], 'tolerance':[0.0,0.0], 'gap':[np.float64(0.1),0.0], 'start_time':['00:00:00.000','00:00:01.000'], 'end_time':['00:00:01.000','00:00:02.000'], 'lines':[['hello'],['world']]})
+    result = audio.merge_chunks(tasks)
+    path = tmp_path / 'tasks.xlsx'
+    result.to_excel(path, index=False)
+    restored = pd.read_excel(path)
+    for value in restored['new_sub_times']:
+        assert isinstance(ast.literal_eval(value)[0][0], float)
+
+
+def test_explicit_upgrade_bypasses_healthy_state(monkeypatch):
+    monkeypatch.setattr(installer, 'load_state', lambda: {'requirements_hash':'same'})
+    monkeypatch.setattr(installer, 'requirements_hash', lambda: 'same')
+    monkeypatch.setattr(installer, 'health_check', lambda **kwargs: 0)
+    calls = []
+    monkeypatch.setattr(installer, 'pip_install', lambda packages, **kwargs: calls.append(kwargs))
+    installer.install_base_requirements()
+    assert not calls
+    installer.install_base_requirements(upgrade=True)
+    assert calls[0]['extra_args'] == ['--upgrade']
+
+
+@pytest.mark.skipif(not __import__('os').environ.get('VIDEOLINGO_TEST_SERVER'), reason='Opt-in live server check')
+def test_live_server(tmp_path):
+    import socket
+    import sys
+    import time
+    import requests
+    from websockets.sync.client import connect
+    from streamlit.proto.BackMsg_pb2 import BackMsg
+    from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+    with socket.socket() as sock:
+        sock.bind(('127.0.0.1', 0))
+        port = sock.getsockname()[1]
+    with (tmp_path / 'server.log').open('w', encoding='utf-8') as log:
+        proc = subprocess.Popen([sys.executable,'-m','streamlit','run',str(ROOT / 'st.py'),'--server.address=127.0.0.1',f'--server.port={port}','--server.headless=true','--browser.gatherUsageStats=false'],cwd=ROOT,stdout=log,stderr=subprocess.STDOUT)
+        try:
+            session = requests.Session()
+            session.trust_env = False
+            deadline = time.monotonic() + 45
+            while True:
+                assert proc.poll() is None
+                try:
+                    if session.get(f'http://127.0.0.1:{port}/_stcore/health',timeout=2).ok:
+                        break
+                except requests.RequestException:
+                    pass
+                assert time.monotonic() < deadline
+                time.sleep(0.2)
+            with connect(f'ws://127.0.0.1:{port}/_stcore/stream',origin=f'http://127.0.0.1:{port}',subprotocols=['streamlit'],proxy=None,max_size=10_000_000) as ws:
+                request = BackMsg()
+                request.rerun_script.query_string = ''
+                ws.send(request.SerializeToString())
+                saw_delta = False
+                while True:
+                    msg = ForwardMsg.FromString(ws.recv(timeout=60))
+                    if msg.WhichOneof('type') == 'delta':
+                        saw_delta = True
+                        assert not msg.delta.new_element.HasField('exception')
+                    if msg.WhichOneof('type') == 'script_finished':
+                        assert saw_delta and msg.script_finished == ForwardMsg.FINISHED_SUCCESSFULLY
+                        break
+        finally:
+            proc.terminate()
+            proc.wait(timeout=20)

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,0 +1,68 @@
+"""Opt-in real GPU + LLM + TTS integration; never runs without explicit inputs.
+
+Set VIDEOLINGO_TEST_AUDIO, VIDEOLINGO_TEST_API_KEY and optionally
+VIDEOLINGO_TEST_BASE_URL / VIDEOLINGO_TEST_MODEL, then run pytest on this file.
+The test spends API credits and writes all media into pytest's temporary directory.
+"""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get('VIDEOLINGO_TEST_AUDIO') or not os.environ.get('VIDEOLINGO_TEST_API_KEY'),
+    reason='Real pipeline requires explicit audio and API credentials',
+)
+
+
+@pytest.fixture
+def configured_workdir(tmp_path, monkeypatch):
+    root = Path(__file__).resolve().parents[1]
+    cfg = yaml.safe_load((root / 'config.yaml').read_text(encoding='utf-8'))
+    cfg['api'].update(key=os.environ['VIDEOLINGO_TEST_API_KEY'], base_url=os.environ.get('VIDEOLINGO_TEST_BASE_URL','https://api.openai.com/v1'), model=os.environ.get('VIDEOLINGO_TEST_MODEL','gpt-4o-mini'))
+    cfg['whisper'].update(language='en', detected_language='en', runtime='local')
+    cfg['tts_method'] = 'edge_tts'
+    cfg['demucs'] = True
+    cfg['burn_subtitles'] = True
+    cfg['pause_before_translate'] = False
+    (tmp_path / 'config.yaml').write_text(yaml.safe_dump(cfg, allow_unicode=True), encoding='utf-8')
+    shutil.copyfile(root / 'custom_terms.xlsx', tmp_path / 'custom_terms.xlsx')
+    monkeypatch.chdir(tmp_path)
+    Path('output').mkdir()
+    try:
+        yield tmp_path
+    finally:
+        # Do not retain the real API credential in pytest artifacts.
+        (tmp_path / 'config.yaml').unlink(missing_ok=True)
+
+
+def test_video_translation_and_dubbing(configured_workdir):
+    subprocess.run(['ffmpeg','-v','error','-f','lavfi','-i','color=c=blue:s=640x360:r=25','-i',os.environ['VIDEOLINGO_TEST_AUDIO'],'-shortest','-c:v','libx264','-c:a','aac','output/sample.mp4'],check=True)
+    from core import _2_asr, _3_1_split_nlp, _3_2_split_meaning, _4_1_summarize, _4_2_translate, _5_split_sub, _6_gen_sub, _7_sub_into_vid, _8_1_audio_task, _8_2_dub_chunks, _9_refer_audio, _10_gen_audio, _11_merge_audio, _12_dub_to_vid
+    steps = [_2_asr.transcribe, _3_1_split_nlp.split_by_spacy, _3_2_split_meaning.split_sentences_by_meaning, _4_1_summarize.get_summary, _4_2_translate.translate_all, _5_split_sub.split_for_sub_main, _6_gen_sub.align_timestamp_main, _7_sub_into_vid.merge_subtitles_to_video, _8_1_audio_task.gen_audio_task_main, _8_2_dub_chunks.gen_dub_chunks, _9_refer_audio.extract_refer_audio_main, _10_gen_audio.gen_audio, _11_merge_audio.merge_full_audio, _12_dub_to_vid.merge_video_audio]
+    from core.st_utils.task_runner import TaskRunner
+    runner = TaskRunner()
+    runner.start([(func.__name__,func) for func in steps])
+    runner._thread.join(timeout=1200)
+    assert not runner._thread.is_alive(), 'Pipeline timed out'
+    assert runner.state == 'completed', runner.error_msg
+    for filename in ('src.srt','trans.srt','output_sub.mp4','output_dub.mp4','dub.mp3'):
+        assert (Path('output') / filename).stat().st_size > 0
+    translated = Path('output/trans.srt').read_text(encoding='utf-8')
+    assert any('\u4e00' <= c <= '\u9fff' for c in translated)
+
+
+def test_audio_only_translation(configured_workdir):
+    shutil.copyfile(os.environ['VIDEOLINGO_TEST_AUDIO'], 'output/sample.wav')
+    from core.utils import update_key
+    update_key('demucs', False)
+    from core import _2_asr, _3_1_split_nlp, _3_2_split_meaning, _4_1_summarize, _4_2_translate, _5_split_sub, _6_gen_sub, _7_sub_into_vid
+    steps = [_2_asr.transcribe, _3_1_split_nlp.split_by_spacy, _3_2_split_meaning.split_sentences_by_meaning, _4_1_summarize.get_summary, _4_2_translate.translate_all, _5_split_sub.split_for_sub_main, _6_gen_sub.align_timestamp_main, _7_sub_into_vid.merge_subtitles_to_video]
+    for step in steps:
+        step()
+    assert Path('output/src.srt').stat().st_size > 0
+    assert any('\u4e00' <= c <= '\u9fff' for c in Path('output/trans.srt').read_text(encoding='utf-8'))
+    assert not Path('output/output_sub.mp4').exists()


### PR DESCRIPTION
## Summary

Refresh the existing dependency stack without replacing WhisperX, Streamlit or the task architecture. This follows the installer work in #577.

- Replace brittle application patch pins with bounded compatibility ranges; remove unused MoviePy, Replicate, direct resampy and duplicate Lightning pins.
- Use Python 3.13 for new uv environments and retain the compatible WhisperX 3.8 / Torch 2.8 / torchvision 0.23 / TorchCodec 0.7 / Transformers 4 stack. Select CUDA 12 wheels even on CUDA 13-capable drivers, and repair accidental CPU wheels on GPU systems.
- Install maintained PyPI Demucs 4.1 with normal dependency resolution instead of a Git snapshot and --no-deps workaround. Load separation lazily.
- Add an explicit --upgrade option, validate declared requirements, remove WMIC dependence and make --check-only non-repairing.
- Share FFmpeg WAV slicing between cloud ASR adapters and run Edge TTS with the active interpreter.
- Fix two end-to-end dubbing failures exposed by pandas 3 / NumPy 2: fractional duration columns and non-portable NumPy scalar repr inside Excel timestamp lists. Propagate FFmpeg subtitle failures.

## Verification

Tested on Windows 11, RTX 4000 Ada 20GB, Python 3.13.15, FFmpeg 9.0.1 shared, Torch 2.8.0+cu128, WhisperX 3.8.6, Streamlit 1.63.0, pandas 3.0.5, NumPy 2.5.3, OpenAI client 3.13.0 and Demucs 4.1.0.

- 15 tests passed, including explicitly enabled real HTTP/WebSocket startup and real GPU/API integration.
- Video: FFmpeg extraction -> Demucs -> WhisperX transcription/word alignment -> spaCy/LLM splitting -> real OpenAI-compatible translation to Simplified Chinese -> SRT/burn-in -> Edge Chinese TTS -> complete dubbed video.
- Audio-only: real transcription/translation and subtitles, with video merging skipped.
- uv pip check: all 201 installed packages compatible.
- installer.py --yes --require-demucs and OneKeyStart.bat --check-only passed.
- Syntax checks and git diff --check passed.

The integration tests are opt-in, consume API credits and use environment-provided credentials. No keys or generated media are included. See docs/runtime-dependencies.md for reproduction and the public test audio.

## Validation limits

Other ASR languages, YouTube availability, Linux/macOS execution and paid 302.ai/ElevenLabs/other TTS services were not live-tested. Cloud adapter slicing has local regression coverage. This PR claims the verified core workflows, not every third-party service or subjective subtitle/dubbing quality.